### PR TITLE
generate event upon dualwan switch

### DIFF
--- a/plugins/routing/routing_plugin.js
+++ b/plugins/routing/routing_plugin.js
@@ -29,6 +29,7 @@ const _ = require('lodash');
 const pclient = require('../../util/redis_manager.js').getPublishClient();
 const wrapIptables = require('../../util/util.js').wrapIptables;
 const exec = require('child-process-promise').exec;
+const era = require('../../event/EventRequestApi.js');
 
 class RoutingPlugin extends Plugin {
    
@@ -615,8 +616,10 @@ class RoutingPlugin extends Plugin {
       this._applyActiveGlobalDefaultRouting(true).then(() => {
         const e = event.buildEvent(event.EVENT_WAN_SWITCHED, {})
         this.propagateEvent(e);
+        const wanConnStates = this.getWANConnStates();
+        era.addActionEvent("dualwan_change",1,{"wan_conn_states":wanConnStates});
         if (changeDesc) {
-          changeDesc.currentStatus = this.getWANConnStates();
+          changeDesc.currentStatus = wanConnStates;
           this.schedulePublishWANConnChanged(changeDesc);
         }
       }).catch((err) => {


### PR DESCRIPTION
Generate an action event upon dual WAN switch, which could be a failover or loadbalance change.

To test, need setup dual WAN in "failover" or "loadbalance" mode, make some network change(like unplug network cable) to trigger action of dual WAN switch and check for events of "dualwan_change"