### PR TITLE
do not flush this._wanStatus in routing_plugin.apply in case it is us…

### DIFF
--- a/plugins/routing/routing_plugin.js
+++ b/plugins/routing/routing_plugin.js
@@ -387,7 +387,8 @@ class RoutingPlugin extends Plugin {
     return new Promise((resolve, reject) => {
       lock.acquire(LOCK_SHARED, async (done) => {
         const lastWanStatus = this._wanStatus || {};
-        this._wanStatus = {};
+        if (!this._wanStatus)
+          this._wanStatus = {};
         this._pendingChangeDescs = this._pendingChangeDescs || [];
         const wanStatus = {};
 


### PR DESCRIPTION
…ed concurrently