### PR TITLE
fix bug #4176 No automatic renewal of DHCP-IPv6...

### DIFF
--- a/scripts/firerouter_dhcpcd_record_lease
+++ b/scripts/firerouter_dhcpcd_record_lease
@@ -2,26 +2,34 @@
 
 case $reason in
   ROUTERADVERT)
-    new_addrs="";
-    gw6="";
+    nd_id=1
+    gw6=""
     vltime="";
-    addr_id=1
-    while [ $addr_id -lt 10 ]; do
-      var_name="nd1_addr$addr_id"
+    while [ $nd_id -lt 10 ]; do
+      nd_name="nd${nd_id}_from"
+      eval "nd_from_tmp=\$$nd_name"
+      if [ -z "$nd_from_tmp" ]; then
+        nd_id=$((nd_id - 1));
+        break
+      fi
+      gw6=${nd_from_tmp}
+      nd_id=$((nd_id + 1));
+    done
+    vltime_name="nd${nd_id}_prefix_information1_vltime"
+    eval "vltime=\$$vltime_name"
+
+    new_addrs=""
+    addr_id=10
+    while [ $addr_id -gt 0 ]; do
+      var_name="nd${nd_id}_addr$addr_id"
       eval "addr=\$$var_name"
       if [ -n "$addr" ]; then
-        new_addrs="$new_addrs$addr,"
-        var_name="nd1_prefix_information${addr_id}_vltime"
-        eval "vltime=\$$var_name"
-      else
-        break;
+        new_addrs="$addr"
+        break
       fi
-      addr_id=$((addr_id + 1))
+      addr_id=$((addr_id - 1))
     done
 
-    if [ -n "$nd1_from" ]; then
-      gw6="$nd1_from"
-    fi
     echo "ip6=$new_addrs\ngw6=$gw6\nra_vltime=$vltime\nra_ts=$(date +%s)" > /dev/shm/dhcpcd.ra.$interface
     ;;
   BOUND6|REBOOT6|RENEW6|REBIND6)

--- a/scripts/firerouter_dhcpcd_update_rt
+++ b/scripts/firerouter_dhcpcd_update_rt
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+execute_and_log() {
+    if [ -z "$1" ]; then
+        return 1
+    fi
+    command="$*"
+    # echo "command: $command" >> /tmp/dhcpcd6.log
+    eval "$command"
+}
+
 metric=${ifmetric:-'1024'}
 mtu=${ifmtu:-'1500'}
 
@@ -16,37 +25,58 @@ ip_changed=""
 case $reason in
 
   ROUTERADVERT)
-    new_addrs="";
-    addr_id=1
-    while [ $addr_id -lt 10 ]; do
-      var_name="nd1_addr$addr_id"
-      prefix_length_var_name="nd1_prefix_information${addr_id}_length"
-      eval "prefix_length=\$$prefix_length_var_name"
-      eval "addr=\$$var_name"
-      if [ -n "$addr" ] && [ $prefix_length -ge 64 ]; then
-        new_addrs="$new_addrs$addr,"
-        for rt_table in $rt_tables; do
-          sudo ip -6 r add $addr dev $interface metric $metric mtu $mtu table $rt_table
-        done
-      else
-        break;
+    # If the IPv6 address of the upstream router changes, we may recieve sevaral groups of nd_* variables, take the last one.
+    nd_id=1
+    nd_from=""
+    while [ $nd_id -lt 10 ]; do
+      nd_name="nd${nd_id}_from"
+      eval "nd_from_tmp=\$$nd_name"
+      if [ -z "$nd_from_tmp" ]; then
+        nd_id=$((nd_id - 1));
+        break
       fi
-      addr_id=$((addr_id + 1))
+      nd_from=${nd_from_tmp}
+      nd_id=$((nd_id + 1));
     done
+    echo "nd_from: ${nd_from}"
+    echo "nd_id: ${nd_id}"
 
-    if [ -n "$nd1_from" ]; then
+    new_addrs=""
+    addr_id=10
+    while [ $addr_id -gt 0 ]; do
+      var_name="nd${nd_id}_addr$addr_id"
+      eval "addr=\$$var_name"
+      if [ -n "$addr" ] && [ -z "$new_addrs" ]; then
+        new_addrs="$addr"
+      elif [ -n "$addr" ]; then
+        # here we should take other addresses as the old addresses and remove them and related routes.
+        for rt_table in $rt_tables; do
+          execute_and_log "sudo ip -6 r del $addr dev $interface table $rt_table"
+        done
+        execute_and_log "sudo ip -6 addr del $addr dev $interface"
+      fi
+      addr_id=$((addr_id - 1))
+    done
+    if [ -n "$new_addrs" ]; then
+      for rt_table in $rt_tables; do
+        execute_and_log "sudo ip -6 r add $new_addrs dev $interface metric $metric mtu $mtu table $rt_table"
+      done
+    fi
+
+    if [ -n "$nd_from" ]; then
       for default_rt_table in $default_rt_tables; do
-        sudo ip -6 r replace default via $nd1_from dev $interface mtu $mtu table $default_rt_table
+        execute_and_log "sudo ip -6 r replace default via $nd_from dev $interface mtu $mtu table $default_rt_table"
       done
       old_gw=`cat /dev/shm/dhcpcd.gw6.$interface 2>/dev/null || echo ""`
-      if [ "$nd1_from" != "$old_gw" ]; then
-        echo $nd1_from > /dev/shm/dhcpcd.gw6.$interface
+      if [ "$nd_from" != "$old_gw" ]; then
+        echo $nd_from > /dev/shm/dhcpcd.gw6.$interface
         ip_changed="1"
       fi
     fi
+
     old_addrs=`cat /dev/shm/dhcpcd.ip6.$interface 2>/dev/null || echo ""`
-    if [ "$new_addrs" != "$old_addrs" ]; then
-      echo $new_addrs > /dev/shm/dhcpcd.ip6.$interface
+    if [ "$new_addrs," != "$old_addrs" ]; then
+      echo "$new_addrs," > /dev/shm/dhcpcd.ip6.$interface
       ip_changed="1"
     fi
     ;;


### PR DESCRIPTION
the bug due to dhcpcd hook scripts  failed to correctly determine the address change and did not trigger redis to publish "dhcpcd6.ip_change" event, so the Firewalla App can not get the latest ip addess, below scripts are modified: 

- modified:   scripts/firerouter_dhcpcd_record_lease
- modified:   scripts/firerouter_dhcpcd_update_rt