### PR TITLE
Fix bug #4464 ignore ULA ipv6 address from RA.

### DIFF
--- a/scripts/firerouter_dhcpcd_record_lease
+++ b/scripts/firerouter_dhcpcd_record_lease
@@ -2,19 +2,32 @@
 
 case $reason in
   ROUTERADVERT)
-    nd_id=1
+    # If the IPv6 address of the upstream router changes, 
+    # we may recieve sevaral groups of nd_* variables, take the last complete ND option set.
+    nd_id=10
     gw6=""
     vltime="";
-    while [ $nd_id -lt 10 ]; do
+    while [ $nd_id -gt 0 ]; do
       nd_name="nd${nd_id}_from"
-      eval "nd_from_tmp=\$$nd_name"
-      if [ -z "$nd_from_tmp" ]; then
+      eval "nd_from_val=\$$nd_name"
+      nd_mtu="nd${nd_id}_mtu"
+      eval "nd_mtu_val=\$$nd_mtu"
+      nd_rdnss1_servers="nd${nd_id}_rdnss1_servers"
+      eval "nd_rdnss1_servers_val=\$$nd_rdnss1_servers"
+      nd_addr1="nd${nd_id}_addr1"
+      eval "nd1_addr1_val=\$$nd_addr1"
+
+      if [ -z "$nd_from_val" -o -z "$nd_mtu_val" -o -z "$nd_rdnss1_servers_val" -o -z "$nd1_addr1_val" ]; then
         nd_id=$((nd_id - 1));
+        continue
+      else
+        gw6=${nd_from_val}
         break
       fi
-      gw6=${nd_from_tmp}
-      nd_id=$((nd_id + 1));
     done
+    if [ -z "$gw6" ]; then
+      exit 0
+    fi
     vltime_name="nd${nd_id}_prefix_information1_vltime"
     eval "vltime=\$$vltime_name"
 

--- a/scripts/firerouter_dhcpcd_update_rt
+++ b/scripts/firerouter_dhcpcd_update_rt
@@ -25,21 +25,32 @@ ip_changed=""
 case $reason in
 
   ROUTERADVERT)
-    # If the IPv6 address of the upstream router changes, we may recieve sevaral groups of nd_* variables, take the last one.
-    nd_id=1
+    # If the IPv6 address of the upstream router changes, 
+    # we may recieve sevaral groups of nd_* variables, take the last complete ND option set.
+    nd_id=10
     nd_from=""
-    while [ $nd_id -lt 10 ]; do
+    while [ $nd_id -gt 0 ]; do
       nd_name="nd${nd_id}_from"
-      eval "nd_from_tmp=\$$nd_name"
-      if [ -z "$nd_from_tmp" ]; then
+      eval "nd_from_val=\$$nd_name"
+      nd_mtu="nd${nd_id}_mtu"
+      eval "nd_mtu_val=\$$nd_mtu"
+      nd_rdnss1_servers="nd${nd_id}_rdnss1_servers"
+      eval "nd_rdnss1_servers_val=\$$nd_rdnss1_servers"
+      nd_addr1="nd${nd_id}_addr1"
+      eval "nd1_addr1_val=\$$nd_addr1"
+
+      if [ -z "$nd_from_val" -o -z "$nd_mtu_val" -o -z "$nd_rdnss1_servers_val" -o -z "$nd1_addr1_val" ]; then
         nd_id=$((nd_id - 1));
+        continue
+      else
+        nd_from=${nd_from_val}
         break
       fi
-      nd_from=${nd_from_tmp}
-      nd_id=$((nd_id + 1));
     done
-    echo "nd_from: ${nd_from}"
-    echo "nd_id: ${nd_id}"
+
+    if [ -z "$nd_from" ]; then
+      exit 0
+    fi
 
     new_addrs=""
     addr_id=10


### PR DESCRIPTION
1. Reproduce: 
- The upstream router is connected with some IOT gateway. By broadcasting ULA routing information through RA, the IOT gateway can autonomously build a local routing table without relying on external routers or DHCP services.
- use command like `sudo tcpdump -i eth0 icmp6 and ip6[40] == 134 -vvv` can watch such RA message on box's ISP interface .
- Such RA messages from the IOT gateway will frequently cause the dhcpcd hook script to be called, causing the ipv6 gateway to be constantly modified. 
```
cat /dev/shm/dhcpcd.gw6.<$interface>
```

2. Solution: 
- The normal RA message from upstream router should include  "MTU" ,"Prefix information" and "Recursive DNS Server" options like below:
```
Internet Control Message Protocol v6
    Type: Router Advertisement (134)
    Code: 0
    Checksum: 0x0a69 [correct]
    [Checksum Status: Good]
    Cur hop limit: 64
    Flags: 0x00, Prf (Default Router Preference): Medium
    Router lifetime (s): 3600
    Reachable time (ms): 0
    Retrans timer (ms): 0
    ICMPv6 Option (Prefix information : 2001:1234:8888::/64)
    ICMPv6 Option (MTU : 1500)
    ICMPv6 Option (Source link-layer address : 20:6d:31:51:00:40)
    ICMPv6 Option (Recursive DNS Server 2001:1234:8888::abcd)
```
- It seems like the RA from IOT gateway only include "Route Information" option, like below:
```
Internet Control Message Protocol v6
    Type: Router Advertisement (134)
    Code: 0
    Checksum: 0x2c4f [correct]
    [Checksum Status: Good]
    Cur hop limit: 0
    Flags: 0x00, Prf (Default Router Preference): Medium
    Router lifetime (s): 0
    Reachable time (ms): 0
    Retrans timer (ms): 0
    ICMPv6 Option (RA Flags Extension)
    ICMPv6 Option (Route Information : Medium fd53:c97f:58e3:1::/64)
```
- So we modify the hook scripts to ignore the ND options set which not include "MTU" ,"Prefix information" and "Recursive DNS Server".

3. Test
- Refer to reproduce steps.

