### PR TITLE
del old route when ipv6 addr changed

### DIFF
--- a/scripts/firerouter_dhcpcd_update_rt
+++ b/scripts/firerouter_dhcpcd_update_rt
@@ -87,6 +87,10 @@ case $reason in
 
     old_addrs=`cat /dev/shm/dhcpcd.ip6.$interface 2>/dev/null || echo ""`
     if [ "$new_addrs," != "$old_addrs" ]; then
+      old_addrs="${old_addrs%,}"
+      for rt_table in $rt_tables; do
+        execute_and_log "sudo ip -6 r del $old_addrs dev $interface table $rt_table"
+      done
       echo "$new_addrs," > /dev/shm/dhcpcd.ip6.$interface
       ip_changed="1"
     fi


### PR DESCRIPTION
The box was first connected to the router at 2002:1234:5679::/64, then unplugged the Ethernet cable and connected to another 240e: 3a3:162f: b751:::/64. There are remnants of old routers in ${inf}_default and ${inf}_local. 