### PR TITLE
prevent replacement of host route in firerouter_dhclient_update_rt; prevent dns route from replacing host route.

### DIFF
--- a/plugins/interface/intf_base_plugin.js
+++ b/plugins/interface/intf_base_plugin.js
@@ -1121,14 +1121,17 @@ class InterfaceBasePlugin extends Plugin {
     if (!_.isArray(dns) || dns.length === 0 || !gateway)
       return;
     for (const dnsIP of dns) {
-      if (new Address4(dnsIP).isValid())
+      if (new Address4(dnsIP).isValid()) {
+        if (dnsIP === gateway) continue;
         await routing.addRouteToTable(dnsIP, gateway, this.name, `${this.name}_default`, null, 4, true)
                       .then(()=>{this._updateDnsRouteCache(dnsIP, gateway, this.name, `${this.name}_default`, 4);})
                       .catch((err) => {});
-      else
+      } else {
+        if (dnsIP === gateway6) continue;
         await routing.addRouteToTable(dnsIP, gateway6, this.name, `${this.name}_default`, null, 6, true)
                       .then(()=>{this._updateDnsRouteCache(dnsIP, gateway6, this.name, `${this.name}_default`, 6);})
                       .catch((err) => {});
+      }
     }
   }
 

--- a/plugins/routing/routing_plugin.js
+++ b/plugins/routing/routing_plugin.js
@@ -61,7 +61,7 @@ class RoutingPlugin extends Plugin {
           let routeRemoved = false;
           if (!af || af == 4) {
             do {
-              await routing.removeRouteFromTable("default", null, null, "main").then(() => {
+              await routing.removeRouteFromTable("default", null, null, routing.RT_MAIN).then(() => {
                 routeRemoved = true;
               }).catch((err) => {
                 routeRemoved = false;
@@ -71,7 +71,7 @@ class RoutingPlugin extends Plugin {
 
           if (!af || af == 6) {
             do {
-              await routing.removeRouteFromTable("default", null, null, "main", 6).then(() => {
+              await routing.removeRouteFromTable("default", null, null, routing.RT_MAIN, 6).then(() => {
                 routeRemoved = true;
               }).catch((err) => {
                 routeRemoved = false;
@@ -83,7 +83,7 @@ class RoutingPlugin extends Plugin {
             if (_.isObject(this._dnsRoutes)) {
               for (const inf of Object.keys(this._dnsRoutes)) {
                 for (const dnsRoute of this._dnsRoutes[inf].filter(i => i.af == 4)) {
-                  await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName :"main", dnsRoute.af).catch((err) => { });
+                  await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName : routing.RT_MAIN, dnsRoute.af).catch((err) => { });
                 }
                 this._dnsRoutes[inf] = this._dnsRoutes[inf].filter(i => i.af != 4);
               }
@@ -94,7 +94,7 @@ class RoutingPlugin extends Plugin {
             if (_.isObject(this._dnsRoutes)) {
               for (const inf of Object.keys(this._dnsRoutes)) {
                 for (const dnsRoute of this._dnsRoutes[inf].filter(i => i.af == 6)) {
-                  await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName :"main", dnsRoute.af).catch((err) => { });
+                  await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName : routing.RT_MAIN, dnsRoute.af).catch((err) => { });
                 }
                 this._dnsRoutes[inf] = this._dnsRoutes[inf].filter(i => i.af != 6);
               }
@@ -210,8 +210,8 @@ class RoutingPlugin extends Plugin {
         for (const dnsRoute of this._dnsRoutes[intf.name]) {
           if (!af || (af && dnsRoute.af == af)) {
             applied.push(dnsRoute);
-            await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName: "main", dnsRoute.af).catch((err) => {
-              this.log.warn(`fail to remove dns route from table ${dnsRoute.tableName || "main"}, err:`, err.message)
+            await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName: routing.RT_MAIN, dnsRoute.af).catch((err) => {
+              this.log.warn(`fail to remove dns route from table ${dnsRoute.tableName || routing.RT_MAIN}, err:`, err.message)
             })
           }
         }
@@ -242,7 +242,7 @@ class RoutingPlugin extends Plugin {
     }
   }
 
-  _updateDnsRouteCache(dnsIP, gw, viaIntf, metric, tableName="main", af=4) {
+  _updateDnsRouteCache(dnsIP, gw, viaIntf, metric, tableName=routing.RT_MAIN, af=4) {
     if (!this._dnsRoutes){
       this._dnsRoutes = {}
     }
@@ -257,6 +257,7 @@ class RoutingPlugin extends Plugin {
     }
     this._dnsRoutes[viaIntf].push({dest: dnsIP, gw: gw, viaIntf: viaIntf, metric: metric, tableName: tableName, af:af});
   }
+
 
   async refreshGlobalIntfRoutes(intf, af = null) {
     await lock.acquire(LOCK_SHARED, async () => {
@@ -307,7 +308,7 @@ class RoutingPlugin extends Plugin {
         const gw = await routing.getInterfaceGWIP(intf, 4);
         if (gw) {
           await this.upsertRouteToTable("default", gw, intf, routing.RT_GLOBAL_DEFAULT, metric, 4).catch((err) => { this.log.warn('fail to upsert route', err.message)});
-          await this.upsertRouteToTable("default", gw, intf, "main", metric, 4).catch((err) => { this.log.warn('fail to upsert route', err.message)});
+          await this.upsertRouteToTable("default", gw, intf, routing.RT_MAIN, metric, 4).catch((err) => { this.log.warn('fail to upsert route', err.message)});
 
           // remove routes in table main except for default
           const mainRules = await routing.searchRouteRules(null, null, intf, 'main');
@@ -318,17 +319,18 @@ class RoutingPlugin extends Plugin {
               }
               const cmd = `sudo ip -${af} route del ${rule} dev ${intf} table main`;
               this.log.debug(`[routing] remove route from table main: ${cmd}`);
-              await exec(cmd).catch((err) => {this.log.warn(`fail to delete route ${cmd}`, err.message)});
+              await exec(cmd).catch((err) => { this.log.warn(`fail to delete route ${cmd}`, err.message) });
             }
           }
 
           const dns = await intfPlugin.getDns4Nameservers();
           if (_.isArray(dns) && dns.length > 0) {
             for (const dnsIP of dns) {
+              if (dnsIP === gw) continue;
               await routing.addRouteToTable(dnsIP, gw, intf, routing.RT_GLOBAL_DEFAULT, metric, 4).catch((err) => {
                 this.log.warn(`fail to add route -4 ${dnsIP} via ${gw} dev ${intf} table ${routing.RT_GLOBAL_DEFAULT}, err:`, err.message)});
-              await routing.addRouteToTable(dnsIP, gw, intf, "main", metric, 4).then(() => {
-                this._updateDnsRouteCache(dnsIP, gw, intf, metric, "main");
+              await routing.addRouteToTable(dnsIP, gw, intf, routing.RT_MAIN, metric, 4).then(() => {
+                this._updateDnsRouteCache(dnsIP, gw, intf, metric, routing.RT_MAIN);
               }).catch((err) => {
                 this.log.warn(`fail to add route -4 ${dnsIP} via ${gw} dev ${intf} table main, err:`, err.message)});
             }
@@ -340,15 +342,16 @@ class RoutingPlugin extends Plugin {
         const gw6 = await routing.getInterfaceGWIP(intf, 6);
         if (gw6) {
           await this.upsertRouteToTable("default", gw6, intf, routing.RT_GLOBAL_DEFAULT, metric, 6).catch((err) => { this.log.warn('fail to upsert route', err)});
-          await this.upsertRouteToTable("default", gw6, intf, "main", metric, 6).catch((err) => { this.log.warn('fail to upsert route', err)});
+          await this.upsertRouteToTable("default", gw6, intf, routing.RT_MAIN, metric, 6).catch((err) => { this.log.warn('fail to upsert route', err)});
 
           const dns6 = await intfPlugin.getDns6Nameservers();
           if (_.isArray(dns6) && dns6.length > 0) {
             for (const dns6IP of dns6) {
+              if (dns6IP === gw6) continue;
               await routing.addRouteToTable(dns6IP, gw6, intf, routing.RT_GLOBAL_DEFAULT, metric, 6).catch((err) => {
                 this.log.warn(`fail to add route -6 ${dns6IP} via ${gw6} dev ${intf} table ${routing.RT_GLOBAL_DEFAULT}, err:`, err.message)});
-              await routing.addRouteToTable(dns6IP, gw6, intf, "main", metric, 6).then(() => {
-                this._updateDnsRouteCache(dns6IP, gw6, intf, metric, "main", 6);
+              await routing.addRouteToTable(dns6IP, gw6, intf, routing.RT_MAIN, metric, 6).then(() => {
+                this._updateDnsRouteCache(dns6IP, gw6, intf, metric, routing.RT_MAIN, 6);
               }).catch((err) => {
                 this.log.warn(`fail to add route -6 ${dns6IP} via ${gw6} dev ${intf} table main, err:`, err.message)});
             }
@@ -412,7 +415,7 @@ class RoutingPlugin extends Plugin {
       let routeRemoved = false;
       if (!af || af == 4) {
         do {
-          await routing.removeRouteFromTable("default", null, null, "main").then(() => {
+          await routing.removeRouteFromTable("default", null, null, routing.RT_MAIN).then(() => {
             routeRemoved = true;
           }).catch((err) => {
             routeRemoved = false;
@@ -423,7 +426,7 @@ class RoutingPlugin extends Plugin {
 
       if (!af || af == 6) {
         do {
-          await routing.removeRouteFromTable("default", null, null, "main", 6).then(() => {
+          await routing.removeRouteFromTable("default", null, null, routing.RT_MAIN, 6).then(() => {
             routeRemoved = true;
           }).catch((err) => {
             routeRemoved = false;
@@ -435,7 +438,7 @@ class RoutingPlugin extends Plugin {
         // remove DNS specific routes
         if (_.isObject(this._dnsRoutes)) {
           for (const dnsRoute of Object.keys(this._dnsRoutes).map(key => this._dnsRoutes[key]).filter(i => i.af == 4)) {
-            await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName : "main", 4).catch((err) => {
+            await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName : routing.RT_MAIN, 4).catch((err) => {
               this.log.warn('fail to remove dns route from table main, err:', err.message)
             });
           }
@@ -446,7 +449,7 @@ class RoutingPlugin extends Plugin {
         // remove DNS specific routes
         if (_.isObject(this._dnsRoutes)) {
           for (const dnsRoute of Object.keys(this._dnsRoutes).map(key => this._dnsRoutes[key]).filter(i => i.af == 6)) {
-            await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName : "main", 6).catch((err) => {
+            await routing.removeRouteFromTable(dnsRoute.dest, dnsRoute.gw, dnsRoute.viaIntf, dnsRoute.tableName ? dnsRoute.tableName : routing.RT_MAIN, 6).catch((err) => {
               this.log.warn('fail to remove dns route from table main, err:', err.message)
             });
           }
@@ -466,7 +469,7 @@ class RoutingPlugin extends Plugin {
         await this._removeDeviceRouting(deadWANIntfs, routing.RT_GLOBAL_DEFAULT, af);
         await this._removeDeviceRouting(deadWANIntfs, routing.RT_GLOBAL_LOCAL, af);
         await this._removeDeviceDnsRouting(deadWANIntfs, af);
-        await this._removeDeviceDefaultRouting(deadWANIntfs, "main", af);
+        await this._removeDeviceDefaultRouting(deadWANIntfs, routing.RT_MAIN, af);
       } else {
         await routing.flushRoutingTable(routing.RT_GLOBAL_DEFAULT, af);
         await routing.flushRoutingTable(routing.RT_GLOBAL_LOCAL, af);
@@ -550,17 +553,18 @@ class RoutingPlugin extends Plugin {
             if (!af || af == 4) {
               if (gw) { // IPv4 default route for inactive WAN is still required for WAN connectivity check
                 await this.upsertRouteToTable("default", gw, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 4).catch((err) => { });
-                await this.upsertRouteToTable("default", gw, viaIntf, "main", metric, 4).catch((err) => { });
+                await this.upsertRouteToTable("default", gw, viaIntf, routing.RT_MAIN, metric, 4).catch((err) => { });
                 // add route for DNS nameserver IP in global_default table
                 const dns = await viaIntfPlugin.getDns4Nameservers();
                 if (_.isArray(dns) && dns.length !== 0) {
                   for (const dnsIP of dns) {
+                    if (dnsIP === gw) continue;
                     await this.upsertRouteToTable(dnsIP, gw, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 4).catch((err) => {
                       this.log.error(`Failed to add route to ${routing.RT_GLOBAL_DEFAULT} for dns ${dnsIP} via ${gw} dev ${viaIntf}`, err.message);
                     });
                     // update all dns routes via the same interface but with new metrics in main table
-                    await this.upsertRouteToTable(dnsIP, gw, viaIntf, "main", metric, 4).then(() => {
-                      this._updateDnsRouteCache(dnsIP, gw, viaIntf, metric, "main");
+                    await this.upsertRouteToTable(dnsIP, gw, viaIntf, routing.RT_MAIN, metric, 4).then(() => {
+                      this._updateDnsRouteCache(dnsIP, gw, viaIntf, metric, routing.RT_MAIN);
                     }).catch((err) => {
                       this.log.error(`Failed to add route to main for dns ${dnsIP} via ${gw} dev ${viaIntf}`, err.message);
                     });
@@ -575,17 +579,18 @@ class RoutingPlugin extends Plugin {
             if ((!af || af == 6) && (this._wanStatus[viaIntf].active === true || type !== 'primary_standby')) { // only add IPv6 default router for primary WAN for primary_standby mode
               if (gw6 && (ready || type === "single")) { // do not add IPv6 default route for inactive WAN under dual WAN setup, WAN connectivity check only uses IPv4
                 await this.upsertRouteToTable("default", gw6, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 6).catch((err) => { });
-                await this.upsertRouteToTable("default", gw6, viaIntf, "main", metric, 6).catch((err) => { });
+                await this.upsertRouteToTable("default", gw6, viaIntf, routing.RT_MAIN, metric, 6).catch((err) => { });
                 // add route for ipv6 DNS nameserver IP in global_default table
                 const dns6 = await viaIntfPlugin.getDns6Nameservers();
                 if (_.isArray(dns6) && dns6.length !== 0 ){
                   for (const dns6IP of dns6) {
+                    if (dns6IP === gw6) continue;
                     await this.upsertRouteToTable(dns6IP, gw6, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 6).catch((err) => {
                       this.log.error(`Failed to add route ipv6 to ${routing.RT_GLOBAL_DEFAULT} for dns ${dns6IP} via ${gw6} dev ${viaIntf}`, err.message);
                     });
                     // update all dns routes via the same interface but with new metrics in main table
-                    await this.upsertRouteToTable(dns6IP, gw6, viaIntf, "main", metric, 6).then(() => {
-                      this._updateDnsRouteCache(dns6IP, gw6, viaIntf, metric, "main", 6);
+                    await this.upsertRouteToTable(dns6IP, gw6, viaIntf, routing.RT_MAIN, metric, 6).then(() => {
+                      this._updateDnsRouteCache(dns6IP, gw6, viaIntf, metric, routing.RT_MAIN, 6);
                     }).catch((err) => {
                       this.log.error(`Failed to add route to main for dns ${dns6IP} via ${gw6} dev ${viaIntf}`, err.message);
                     });
@@ -608,7 +613,7 @@ class RoutingPlugin extends Plugin {
             if (lastActiveIntf && lastActiveIntf !== currentActiveIntf) {
               const gw6 = await routing.getInterfaceGWIP(lastActiveIntf, 6);
               await routing.removeRouteFromTable("default", gw6, lastActiveIntf, routing.RT_GLOBAL_DEFAULT, 6).catch((err) => { });
-              await routing.removeRouteFromTable("default", gw6, lastActiveIntf, "main", 6).catch((err) => { });
+              await routing.removeRouteFromTable("default", gw6, lastActiveIntf, routing.RT_MAIN, 6).catch((err) => { });
             }
           }
 
@@ -663,25 +668,26 @@ class RoutingPlugin extends Plugin {
                   multiPathDesc.push({ nextHop: gw, dev: viaIntf, weight: weight });
                 } else {
                   await routing.addRouteToTable("default", gw, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 4).catch((err) => { });
-                  await routing.addRouteToTable("default", gw, viaIntf, "main", metric, 4).catch((err) => { });
+                  await routing.addRouteToTable("default", gw, viaIntf, routing.RT_MAIN, metric, 4).catch((err) => { });
                 }
                 // add route for DNS nameserver IP in global_default table
                 const dns = await viaIntfPlugin.getDns4Nameservers();
                 if (_.isArray(dns) && dns.length !== 0) {
                   for (const dnsIP of dns) {
+                    if (dnsIP === gw) continue;
                     await routing.addRouteToTable(dnsIP, gw, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 4, true).catch((err) => {
                       this.log.error(`Failed to add route to ${routing.RT_GLOBAL_DEFAULT} for dns ${dnsIP} via ${gw} dev ${viaIntf}`, err.message);
                     });
                     let dnsRouteRemoved = false;
                     // remove all dns routes via the same interface but with different metrics in main table
                     do {
-                      await routing.removeRouteFromTable(dnsIP, gw, viaIntf, "main").then(() => {
+                      await routing.removeRouteFromTable(dnsIP, gw, viaIntf, routing.RT_MAIN).then(() => {
                         dnsRouteRemoved = true;
                       }).catch((err) => {
                         dnsRouteRemoved = false;
                       })
                     } while (dnsRouteRemoved)
-                    await routing.addRouteToTable(dnsIP, gw, viaIntf, "main", metric, 4, true).catch((err) => {
+                    await routing.addRouteToTable(dnsIP, gw, viaIntf, routing.RT_MAIN, metric, 4, true).catch((err) => {
                       this.log.error(`Failed to add route to main for dns ${dnsIP} via ${gw} dev ${viaIntf}`, err.message);
                     });
                     if (!this._dnsRoutes){
@@ -691,7 +697,7 @@ class RoutingPlugin extends Plugin {
                     if (!this._dnsRoutes[viaIntf]) {
                       this._dnsRoutes[viaIntf] = [];
                     }
-                    this._dnsRoutes[viaIntf].push({dest: dnsIP, gw: gw, viaIntf: viaIntf, metric: metric, tableName: "main", af: af});
+                    this._dnsRoutes[viaIntf].push({dest: dnsIP, gw: gw, viaIntf: viaIntf, metric: metric, tableName: routing.RT_MAIN, af: af});
                   }
                 }
               } else {
@@ -708,26 +714,27 @@ class RoutingPlugin extends Plugin {
                   /*
                   const metric = this._wanStatus[viaIntf].seq + 100;
                   await routing.addRouteToTable("default", gw6, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 6).catch((err) => { });
-                  await routing.addRouteToTable("default", gw6, viaIntf, "main", metric, 6).catch((err) => { });
+                  await routing.addRouteToTable("default", gw6, viaIntf, routing.RT_MAIN, metric, 6).catch((err) => { });
                   */
                 }
                 // add route for ipv6 DNS nameserver IP in global_default table
                 const dns6 = await viaIntfPlugin.getDns6Nameservers();
                 if (_.isArray(dns6) && dns6.length !== 0) {
                   for (const dns6IP of dns6) {
+                    if (dns6IP === gw6) continue;
                     await routing.addRouteToTable(dns6IP, gw6, viaIntf, routing.RT_GLOBAL_DEFAULT, metric, 6, true).catch((err) => {
                       this.log.error(`Failed to add route to ${routing.RT_GLOBAL_DEFAULT} for dns ${dns6IP} via ${gw6} dev ${viaIntf}`, err.message);
                     });
                     let dnsRouteRemoved = false;
                     // remove all ipv6 dns routes via the same interface but with different metrics in main table
                     do {
-                      await routing.removeRouteFromTable(dns6IP, gw6, viaIntf, "main", 6).then(() => {
+                      await routing.removeRouteFromTable(dns6IP, gw6, viaIntf, routing.RT_MAIN, 6).then(() => {
                         dnsRouteRemoved = true;
                       }).catch((err) => {
                         dnsRouteRemoved = false;
                       })
                     } while (dnsRouteRemoved)
-                    await routing.addRouteToTable(dns6IP, gw6, viaIntf, "main", metric, 6, true).catch((err) => {
+                    await routing.addRouteToTable(dns6IP, gw6, viaIntf, routing.RT_MAIN, metric, 6, true).catch((err) => {
                       this.log.error(`Failed to add route to main for dns ${dns6IP} via ${gw6} dev ${viaIntf}`, err.message);
                     });
                     if (!this._dnsRoutes){
@@ -737,7 +744,7 @@ class RoutingPlugin extends Plugin {
                     if (!this._dnsRoutes[viaIntf]) {
                       this._dnsRoutes[viaIntf] = [];
                     }
-                    this._dnsRoutes[viaIntf].push({dest: dns6IP, gw: gw6, viaIntf: viaIntf, metric: metric, tableName: "main", af: af});
+                    this._dnsRoutes[viaIntf].push({dest: dns6IP, gw: gw6, viaIntf: viaIntf, metric: metric, tableName: routing.RT_MAIN, af: af});
                   }
                 }
               } else {
@@ -758,11 +765,11 @@ class RoutingPlugin extends Plugin {
           }
           if (multiPathDesc.length > 0) {
             await routing.addMultiPathRouteToTable("default", routing.RT_GLOBAL_DEFAULT, 4, 1, ...multiPathDesc).catch((err) => { });
-            await routing.addMultiPathRouteToTable("default", "main", 4, 1, ...multiPathDesc).catch((err) => { });
+            await routing.addMultiPathRouteToTable("default", routing.RT_MAIN, 4, 1, ...multiPathDesc).catch((err) => { });
           }
           if (multiPathDesc6.length > 0) {
             await routing.addMultiPathRouteToTable("default", routing.RT_GLOBAL_DEFAULT, 6, 1, ...multiPathDesc6).catch((err) => { });
-            await routing.addMultiPathRouteToTable("default", "main", 6, 1, ...multiPathDesc6).catch((err) => { });
+            await routing.addMultiPathRouteToTable("default", routing.RT_MAIN, 6, 1, ...multiPathDesc6).catch((err) => { });
           }
 
           break;

--- a/scripts/firerouter_dhclient_update_rt
+++ b/scripts/firerouter_dhclient_update_rt
@@ -18,6 +18,11 @@ add_route() {
     return 0
   fi
 
+  # when dhcp_server and gateway are the same, no need to add a separate host route
+  if [ "$dhcp_server" = "$gateway" ]; then
+    return 0
+  fi
+
   for rt_table in $rt_tables; do
     if [ -z "$gateway" ]; then
       execute_and_log "sudo ip route replace $dhcp_server dev $iface table $rt_table"

--- a/tests/plugins/test_routing.js
+++ b/tests/plugins/test_routing.js
@@ -253,7 +253,6 @@ describe('Test Routing WAN', function(){
     let afterResults = await routing.searchRouteRules(null, null, 'eth0', 'main');
     expect(afterResults.length).to.be.equal(beforeResults.length);
   });
-
 });
 
 describe('Test Routing DNS', function(){

--- a/util/routing.js
+++ b/util/routing.js
@@ -27,6 +27,7 @@ const RT_GLOBAL_DEFAULT = "global_default";
 const RT_STATIC = "static";
 const RT_WAN_ROUTABLE = "wan_routable";
 const RT_LAN_ROUTABLE = "lan_routable";
+const RT_MAIN = "main";
 
 const RT_TYPE_VC = "RT_TYPE_VC";
 const RT_TYPE_REG = "RT_TYPE_REG";
@@ -381,6 +382,7 @@ module.exports = {
   RT_GLOBAL_DEFAULT: RT_GLOBAL_DEFAULT,
   RT_WAN_ROUTABLE: RT_WAN_ROUTABLE,
   RT_LAN_ROUTABLE: RT_LAN_ROUTABLE,
+  RT_MAIN: RT_MAIN,
   RT_STATIC: RT_STATIC,
   RT_TYPE_REG,
   RT_TYPE_VC,


### PR DESCRIPTION
prevent replacement of host route in firerouter_dhclient_update_rt; prevent dns route from replacing host route.

https://github.com/firewalla/firecommit/issues/7424