### PR TITLE
add vxlan interface plugin

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -76,6 +76,12 @@
       "init_seq": 6
     },
     {
+      "file_path": "./interface/vxlan_intf_plugin.js",
+      "config_path": "interface.vxlan",
+      "category": "interface",
+      "init_seq": 6
+    },
+    {
       "file_path": "./nat/nat_plugin.js",
       "config_path": "nat",
       "category": "nat",

--- a/plugins/interface/vxlan_intf_plugin.js
+++ b/plugins/interface/vxlan_intf_plugin.js
@@ -1,0 +1,85 @@
+/*    Copyright 2026 Firewalla Inc
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+const InterfaceBasePlugin = require('./intf_base_plugin.js');
+
+const exec = require('child-process-promise').exec;
+const pl = require('../plugin_loader.js');
+
+// config keys under interface.vxlan.<name>:
+//   vni      (required)  VXLAN Network Identifier
+//   intf                 underlay interface the encap egresses (e.g. "br0")
+//   local                underlay source IP
+//   remote               peer underlay IP (unicast; mutually exclusive with group)
+//   group                multicast group
+//   dstport  (def 4789)  UDP destination port
+class VXLANInterfacePlugin extends InterfaceBasePlugin {
+
+  static async preparePlugin() {
+    await exec(`sudo modprobe vxlan`).catch((err) => {});
+  }
+
+  async flush() {
+    await super.flush();
+
+    if (this.networkConfig && this.networkConfig.enabled) {
+      await exec(`sudo ip link set ${this.name} down`).catch((err) => {});
+      await exec(`sudo ip link delete ${this.name}`).catch((err) => {});
+    }
+  }
+
+  async createInterface() {
+    const c = this.networkConfig;
+    if (c.vni === undefined || c.vni === null) {
+      this.fatal(`Missing vni for vxlan interface ${this.name}`);
+    }
+    let cmd = `sudo ip link add ${this.name} type vxlan id ${c.vni}`;
+    if (c.intf) cmd += ` dev ${c.intf}`;
+    if (c.local) cmd += ` local ${c.local}`;
+    if (c.group) cmd += ` group ${c.group}`;
+    else if (c.remote) cmd += ` remote ${c.remote}`;
+    cmd += ` dstport ${c.dstport || 4789}`;
+    await exec(cmd).catch((err) => {
+      this.log.error(`Failed to create vxlan interface ${this.name}`, err.message);
+    });
+
+    // react to changes of the underlay interface when it is managed (mirrors vlan)
+    if (c.intf) {
+      const intfPlugin = pl.getPluginInstance("interface", c.intf);
+      if (intfPlugin)
+        this.subscribeChangeFrom(intfPlugin);
+      else
+        this.log.warn(`Underlay interface plugin not found for ${this.name}: ${c.intf}`);
+    }
+    return true;
+  }
+
+  getDefaultMTU() {
+    // vxlan adds 50 bytes of encapsulation over IPv4 (1500 - 50)
+    return 1450;
+  }
+
+  async getSubIntfs() {
+    return this.networkConfig.intf ? [this.networkConfig.intf] : [];
+  }
+
+  isEthernetBasedInterface() {
+    return true;
+  }
+}
+
+module.exports = VXLANInterfacePlugin;


### PR DESCRIPTION
Part of a 2-PR stack: **#1902** (this) vxlan interface plugin · **#1903** network config overlay. Independent; better together.

## Why
Today a vxlan can only be terminated on the box by creating the netdev out-of-band and adopting it through the `phy` plugin — FireRouter never manages its lifecycle. There is no native vxlan interface type.

## How
Adds one, modeled on the `vlan` plugin: `modprobe vxlan`, create the link with `ip link add … type vxlan …`, delete it on flush, and re-apply when its underlay (`intf`) changes if that underlay is managed. Declared under `interface.vxlan.<name>`; with `meta.type: lan` it is monitored, DHCP-served, and firewalled like any LAN. Default MTU 1450 (1500 underlay − 50 overhead).

Config keys: `vni` (required), `intf` (underlay), `local`, `remote`/`group`, `dstport` (default 4789).

```jsonc
"interface": {
  "vxlan": {
    "vxlan99": {
      "enabled": true,
      "meta": { "type": "lan", "name": "exp" },
      "vni": 99,
      "intf": "br0",
      "local": "10.86.1.1",
      "remote": "10.86.1.32",
      "ipv4": "10.99.0.1/24"
    }
  }
}
```
