### PR TITLE
support a network config overlay file

### DIFF
--- a/core/network_config_mgr.js
+++ b/core/network_config_mgr.js
@@ -647,6 +647,62 @@ class NetworkConfigManager {
     return config;
   }
 
+  // --- admin-managed network-config overlay -------------------------------
+  // An optional file that is deep-merged onto the active config when applying
+  // and when reporting /config/active, but is NEVER written back into
+  // sysdb:networkConfig. This lets an admin add interfaces (e.g. a vxlan LAN)
+  // that survive the app re-pushing its config and survive reboots, without
+  // FireRouter ever mutating the app-owned config. Mirrors how the system
+  // config already overlays routeConfig.json (see util/config.js).
+  getNetworkConfigOverlayPath() {
+    return `${r.getUserConfigFolder()}/network_config_overlay.json`;
+  }
+
+  async getNetworkConfigOverlay() {
+    const f = this.getNetworkConfigOverlayPath();
+    const exists = await fsp.access(f).then(() => true).catch(() => false);
+    if (!exists)
+      return null;
+    try {
+      return JSON.parse(await fsp.readFile(f, "utf8"));
+    } catch (err) {
+      log.error(`Failed to parse network config overlay ${f}`, err.message);
+      return null;
+    }
+  }
+
+  // deep-merge the overlay onto config (overlay wins; arrays are replaced, not merged)
+  async mergeNetworkConfigOverlay(config) {
+    const overlay = await this.getNetworkConfigOverlay();
+    if (!overlay || !config)
+      return config;
+    return _.mergeWith({}, config, overlay, (objVal, srcVal) => {
+      if (_.isArray(srcVal)) return srcVal;
+    });
+  }
+
+  // remove overlay-introduced keys so the overlay is never persisted into the app config
+  async stripNetworkConfigOverlay(config) {
+    const overlay = await this.getNetworkConfigOverlay();
+    if (!overlay || !config)
+      return config;
+    const stripped = _.cloneDeep(config);
+    const prune = (base, ov) => {
+      for (const k of Object.keys(ov)) {
+        if (!(k in base)) continue;
+        if (_.isPlainObject(ov[k]) && _.isPlainObject(base[k])) {
+          prune(base[k], ov[k]);
+          if (_.isEmpty(base[k])) delete base[k];
+        } else {
+          delete base[k];
+        }
+      }
+    };
+    prune(stripped, overlay);
+    return stripped;
+  }
+  // ------------------------------------------------------------------------
+
   async validateConfig(config) {
     if (!config)
       return ["config is not defined"];
@@ -711,6 +767,11 @@ class NetworkConfigManager {
 
   async tryApplyConfig(config, dryRun = false) {
     const currentConfig = (await this.getActiveConfig()) || (await this.getDefaultConfig());
+    // layer the admin overlay on top of both the new config and the rollback
+    // target, so applying (and rolling back) reflects the same effective state.
+    // The overlay is never persisted — see saveConfig().
+    config = await this.mergeNetworkConfigOverlay(config);
+    const rollbackConfig = await this.mergeNetworkConfigOverlay(currentConfig);
     // convert new config to integrated AP config
     const convertedConfig = await this.convertIntegratedAPConfig(config).catch((err) => {
       log.error(`Failed to convert effective config`, err.message);
@@ -720,9 +781,9 @@ class NetworkConfigManager {
     if (errors && errors.length != 0) {
       log.error("Failed to apply network config, rollback to previous setup", errors);
       // convert current config to integrated AP config
-      const convertedCurrentConfig = await this.convertIntegratedAPConfig(currentConfig).catch((err) => {
+      const convertedCurrentConfig = await this.convertIntegratedAPConfig(rollbackConfig).catch((err) => {
         log.error(`Failed to convert effective config`, err.message);
-        return currentConfig;
+        return rollbackConfig;
       });
       await ns.setup(convertedCurrentConfig).catch((err) => {
         log.error("Failed to rollback network config", err);
@@ -764,7 +825,9 @@ class NetworkConfigManager {
     if (!networkConfig.ncid && !transaction) {
       networkConfig.ncid = util.generateUUID();
     }
-    const configString = JSON.stringify(networkConfig);
+    // never persist overlay-defined keys into the app-owned config
+    const toStore = await this.stripNetworkConfigOverlay(networkConfig);
+    const configString = JSON.stringify(toStore);
     if (configString) {
       await rclient.setAsync(transaction ? "sysdb:transaction:networkConfig" : "sysdb:networkConfig", configString);
       this._scheduleRedisBackgroundSave();

--- a/service/routes/config.js
+++ b/service/routes/config.js
@@ -54,7 +54,8 @@ const T_REVERT_TIMEOUT = 120 * 1000; // revert back to previous persisted config
 router.get('/active', async (req, res, next) => {
   const config = await ncm.getActiveConfig(inTransaction);
   if(config) {
-    res.json(config);
+    // report the effective config incl. the admin overlay (never persisted)
+    res.json(await ncm.mergeNetworkConfigOverlay(config));
   } else {
     res.status(404).send('');
   }


### PR DESCRIPTION
Part of a 2-PR stack: **#1902** vxlan interface plugin · **#1903** (this) network config overlay. Independent; better together.

## Why
The app owns the entire `sysdb:networkConfig`, so there is no supported way to add your own interface that survives the app rewriting that config — or a reboot. An admin-defined vxlan LAN, for example, is dropped on the next app change.

## How
Adds an optional `~/.router/config/network_config_overlay.json`. It is deep-merged onto the active config when applying (`tryApplyConfig`) and when serving `/config/active`, and stripped back out in `saveConfig` — so it is never written into `sysdb:networkConfig`. The app's own config is therefore never touched: delete the file and the next apply reverts it; absent, it does nothing. Mirrors how the system config already overlays `routeConfig.json` (`util/config.js`).

```json
{
  "interface": {
    "vxlan": {
      "vxlan99": {
        "enabled": true,
        "meta": { "type": "lan", "name": "exp" },
        "vni": 99,
        "intf": "br0",
        "local": "10.86.1.1",
        "remote": "10.86.1.32",
        "ipv4": "10.99.0.1/24"
      }
    }
  },
  "dhcp": {
    "vxlan99": {
      "gateway": "10.99.0.1",
      "subnetMask": "255.255.255.0",
      "range": { "from": "10.99.0.100", "to": "10.99.0.200" }
    }
  }
}
```
