### PR TITLE
Fix upgrade script not aborting on git fetch/reset failure

### DIFF
--- a/scripts/firerouter_upgrade.sh
+++ b/scripts/firerouter_upgrade.sh
@@ -154,7 +154,13 @@ GIT_COMMAND="(sudo -u pi $MGIT fetch origin $remote_branch && sudo -u pi $MGIT r
 eval $GIT_COMMAND ||
   (sleep 3; eval $GIT_COMMAND) ||
   (sleep 3; eval $GIT_COMMAND) ||
-  (sleep 3; eval $GIT_COMMAND) || (date >> ~/.firerouter.upgrade.failed; exit 1)
+  (sleep 3; eval $GIT_COMMAND) || {
+    date >> ~/.firerouter.upgrade.failed
+    /home/pi/firerouter/scripts/firelog -t local -m "FIREROUTER.UPGRADE($mode) Failed git fetch/reset "+`date`
+    rm -f /dev/shm/firerouter.upgraded
+    touch /dev/shm/firerouter.upgrade.failed
+    exit 1
+  }
 
 # set node_modules link to the proper directory
 NODE_MODULES_PATH=$(get_node_modules_dir)


### PR DESCRIPTION
## Problem

In `scripts/firerouter_upgrade.sh`, the terminal failure handler of the git fetch/reset retry chain ran in a **subshell**:

```bash
... || (date >> ~/.firerouter.upgrade.failed; exit 1)
```

The `exit 1` only exits the subshell, so when the fetch persistently fails (e.g. unreachable/private remote), the script falls through and still runs `touch /dev/shm/firerouter.upgraded` — reporting success on a failed upgrade.

`bin/fireboot` then sees the upgraded flag and runs `systemctl restart firerouter`. Since `fireboot.service` has `Requires=firerouter.service`, the restart propagates back to fireboot, which gets SIGTERM mid-run, gets restarted by systemd, re-runs the upgrade, fails again — an endless restart loop, one cycle every ~30 seconds.

Observed live on a box whose `origin` was unreachable: `fireboot.service: Main process exited, code=killed, status=15/TERM` every ~30s, with 168 entries in `~/.firerouter.upgrade.failed`.

## Fix

Replace the subshell with a brace group so the script actually exits on failure, and mirror the existing no-network failure path: remove `/dev/shm/firerouter.upgraded`, touch `/dev/shm/firerouter.upgrade.failed`, and log via firelog.

The three intermediate retry attempts remain subshells, as they should only fail the `||` chain.

## Verification

Deployed the fixed script to the affected box: the next fireboot run logged `FIREROUTER.UPGRADE() Failed git fetch/reset`, skipped the firerouter restart, and finished cleanly (`status=0/SUCCESS`); the restart loop stopped immediately.