### PR TITLE
Make LAN IPv6 Router Advertisement lifetime configurable

### DIFF
--- a/plugins/dhcp/dhcp6_plugin.js
+++ b/plugins/dhcp/dhcp6_plugin.js
@@ -38,13 +38,17 @@ class DHCP6Plugin extends DHCPPlugin {
     this._restartService();
   }
 
-  async writeDHCPConfFile(iface, tags, type = "stateless", from, to, nameservers, prefixLen, leaseTime = 86400, raInterval = 200, raLifetime = 3600) {
+  async writeDHCPConfFile(iface, tags, type = "stateless", from, to, nameservers, prefixLen, leaseTime = 86400, raInterval = 200, raLifetime) {
     tags = tags || [];
     nameservers = nameservers || [];
     let extraTags = "";
     type = type || "stateless";
     if (tags.length > 0) {
       extraTags = tags.map(tag => `tag:${tag}`).join(",") + ",";
+    }
+
+    if (raLifetime === undefined) {
+      raLifetime = Math.max(3600, raInterval);
     }
 
     if (!Number.isInteger(raLifetime) || raLifetime < 0 || raLifetime > 65535 || (raLifetime !== 0 && raLifetime < raInterval)) {

--- a/plugins/dhcp/dhcp6_plugin.js
+++ b/plugins/dhcp/dhcp6_plugin.js
@@ -38,7 +38,7 @@ class DHCP6Plugin extends DHCPPlugin {
     this._restartService();
   }
 
-  async writeDHCPConfFile(iface, tags, type = "stateless", from, to, nameservers, prefixLen, leaseTime = 86400, raInterval = 200) {
+  async writeDHCPConfFile(iface, tags, type = "stateless", from, to, nameservers, prefixLen, leaseTime = 86400, raInterval = 200, raLifetime = 3600) {
     tags = tags || [];
     nameservers = nameservers || [];
     let extraTags = "";
@@ -46,6 +46,11 @@ class DHCP6Plugin extends DHCPPlugin {
     if (tags.length > 0) {
       extraTags = tags.map(tag => `tag:${tag}`).join(",") + ",";
     }
+
+    if (!Number.isInteger(raLifetime) || raLifetime < 0 || raLifetime > 65535) {
+      this.fatal(`raLifetime for dhcp6 of ${this.name} should be an integer between 0 and 65535`);
+    }
+
     const content = [];
 
     if (nameservers.length > 0){
@@ -59,7 +64,7 @@ class DHCP6Plugin extends DHCPPlugin {
         // simply use slaac to configure client IPv6 address
         content.push(`dhcp-range=tag:${iface},${extraTags}::,constructor:${this.name},slaac,${leaseTime}`);
         content.push('enable-ra');
-        content.push(`ra-param=${iface},${raInterval},3600`);
+        content.push(`ra-param=${iface},${raInterval},${raLifetime}`);
         break;
       }
       case "stateful": {
@@ -69,7 +74,7 @@ class DHCP6Plugin extends DHCPPlugin {
           this.fatal(`prefixLen for dhcp6 of ${this.name} should be at least 64`);
         content.push(`dhcp-range=tag:${iface},${extraTags}${from},${to},${prefixLen},${leaseTime}`);
         content.push('enable-ra');
-        content.push(`ra-param=${iface},${raInterval},3600`);
+        content.push(`ra-param=${iface},${raInterval},${raLifetime}`);
         break;
       }
       default:
@@ -94,7 +99,7 @@ class DHCP6Plugin extends DHCPPlugin {
       return;
     }
     await this.writeDHCPConfFile(iface, this.networkConfig.tags, this.networkConfig.type, this.networkConfig.range && this.networkConfig.range.from, this.networkConfig.range && this.networkConfig.range.to, this.networkConfig.nameservers,
-      this.networkConfig.prefixLen, this.networkConfig.lease, this.networkConfig.raInterval);
+      this.networkConfig.prefixLen, this.networkConfig.lease, this.networkConfig.raInterval, this.networkConfig.raLifetime);
     this._restartService();
   }
 }

--- a/plugins/dhcp/dhcp6_plugin.js
+++ b/plugins/dhcp/dhcp6_plugin.js
@@ -47,8 +47,8 @@ class DHCP6Plugin extends DHCPPlugin {
       extraTags = tags.map(tag => `tag:${tag}`).join(",") + ",";
     }
 
-    if (!Number.isInteger(raLifetime) || raLifetime < 0 || raLifetime > 65535) {
-      this.fatal(`raLifetime for dhcp6 of ${this.name} should be an integer between 0 and 65535`);
+    if (!Number.isInteger(raLifetime) || raLifetime < 0 || raLifetime > 65535 || (raLifetime !== 0 && raLifetime < raInterval)) {
+      this.fatal(`raLifetime for dhcp6 of ${this.name} should be 0 or an integer between raInterval and 65535`);
     }
 
     const content = [];

--- a/test/plugins/test_dhcp6_plugin.js
+++ b/test/plugins/test_dhcp6_plugin.js
@@ -51,6 +51,15 @@ describe('Test DHCP6 configuration', function(){
     expect(contents).to.contain('ra-param=eth5,200,3600');
   });
 
+  it('should use the interval as the default Router Advertisement lifetime when it exceeds 3600 seconds', async () => {
+    await this.plugin.writeDHCPConfFile(
+      'eth5', [], 'stateless', undefined, undefined, [], undefined, 86400, 4000
+    );
+
+    const contents = await fs.readFileAsync(this.plugin._getConfFilePath(), {encoding: 'utf8'});
+    expect(contents).to.contain('ra-param=eth5,4000,4000');
+  });
+
   it('should allow Router Advertisement lifetime to be disabled with 0 seconds', async () => {
     await this.plugin.writeDHCPConfFile(
       'eth5',

--- a/test/plugins/test_dhcp6_plugin.js
+++ b/test/plugins/test_dhcp6_plugin.js
@@ -1,0 +1,140 @@
+/*    Copyright 2016-2026 Firewalla Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict'
+
+const chai = require('chai');
+const expect = chai.expect;
+const fs = require('fs');
+
+const DHCP6Plugin = require('../../plugins/dhcp/dhcp6_plugin.js');
+
+
+describe('Test DHCP6 configuration', function(){
+  this.timeout(30000);
+
+  beforeEach(() => {
+    this.plugin = new DHCP6Plugin("eth5");
+    this.plugin.configure({});
+  });
+
+  afterEach(async () => {
+    await fs.unlinkAsync(this.plugin._getConfFilePath()).catch(() => null);
+  });
+
+  it('should use the default Router Advertisement lifetime of 3600 seconds', async () => {
+    await this.plugin.writeDHCPConfFile(
+      'eth5',
+      [],
+      'stateless',
+      undefined,
+      undefined,
+      [],
+      undefined,
+      86400,
+      200
+    );
+
+    const contents = await fs.readFileAsync(this.plugin._getConfFilePath(), {encoding: 'utf8'});
+    expect(contents).to.contain('ra-param=eth5,200,3600');
+  });
+
+  it('should allow Router Advertisement lifetime to be disabled with 0 seconds', async () => {
+    await this.plugin.writeDHCPConfFile(
+      'eth5',
+      [],
+      'stateless',
+      undefined,
+      undefined,
+      [],
+      undefined,
+      86400,
+      200,
+      0
+    );
+
+    const contents = await fs.readFileAsync(this.plugin._getConfFilePath(), {encoding: 'utf8'});
+    expect(contents).to.contain('ra-param=eth5,200,0');
+  });
+
+  it('should use a configured Router Advertisement lifetime in stateful mode', async () => {
+    await this.plugin.writeDHCPConfFile(
+      'eth5',
+      [],
+      'stateful',
+      '2001:db8:1::10',
+      '2001:db8:1::100',
+      [],
+      64,
+      86400,
+      200,
+      900
+    );
+
+    const contents = await fs.readFileAsync(this.plugin._getConfFilePath(), {encoding: 'utf8'});
+    expect(contents).to.contain('ra-param=eth5,200,900');
+  });
+
+  it('should reject invalid Router Advertisement lifetimes', async () => {
+    const invalidLifetimes = [-1, 65536, 1.5, '3600'];
+
+    for (const raLifetime of invalidLifetimes) {
+      let error = null;
+      try {
+        await this.plugin.writeDHCPConfFile(
+          'eth5',
+          [],
+          'stateless',
+          undefined,
+          undefined,
+          [],
+          undefined,
+          86400,
+          200,
+          raLifetime
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.not.equal(null);
+      expect(String(error)).to.contain('raLifetime');
+    }
+  });
+
+  it('should reject invalid Router Advertisement lifetime before writing configuration', async () => {
+    let error = null;
+    try {
+      await this.plugin.writeDHCPConfFile(
+        'eth5',
+        [],
+        'stateless',
+        undefined,
+        undefined,
+        [],
+        undefined,
+        86400,
+        200,
+        -1
+      );
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).to.not.equal(null);
+    const exists = await fs.accessAsync(this.plugin._getConfFilePath()).then(() => true).catch(() => false);
+    expect(exists).to.equal(false);
+  });
+});

--- a/test/plugins/test_dhcp6_plugin.js
+++ b/test/plugins/test_dhcp6_plugin.js
@@ -87,6 +87,29 @@ describe('Test DHCP6 configuration', function(){
     expect(contents).to.contain('ra-param=eth5,200,900');
   });
 
+  it('should reject a nonzero Router Advertisement lifetime below the interval', async () => {
+    let error = null;
+    try {
+      await this.plugin.writeDHCPConfFile(
+        'eth5', [], 'stateless', undefined, undefined, [], undefined, 86400, 200, 199
+      );
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).to.not.equal(null);
+    expect(String(error)).to.contain('raLifetime');
+  });
+
+  it('should allow a Router Advertisement lifetime equal to the interval', async () => {
+    await this.plugin.writeDHCPConfFile(
+      'eth5', [], 'stateless', undefined, undefined, [], undefined, 86400, 200, 200
+    );
+
+    const contents = await fs.readFileAsync(this.plugin._getConfFilePath(), {encoding: 'utf8'});
+    expect(contents).to.contain('ra-param=eth5,200,200');
+  });
+
   it('should reject invalid Router Advertisement lifetimes', async () => {
     const invalidLifetimes = [-1, 65536, 1.5, '3600'];
 


### PR DESCRIPTION
This change makes the IPv6 Router Advertisement Router Lifetime configurable for LAN DHCPv6 networks.

FireRouter currently hard-codes the Router Advertisement Router Lifetime to 3600 seconds for both stateless and stateful DHCPv6 configurations. This prevents deployments that need to advertise an IPv6 prefix and other RA information without advertising the FireRouter interface as an IPv6 default router.

## Changes

- Add an optional `raLifetime` DHCPv6 network configuration property.
- Default an omitted `raLifetime` to 3600 seconds, or to `raInterval` when the configured interval exceeds 3600 seconds.
- Apply the configured Router Lifetime to both stateless and stateful DHCPv6 RA configurations.
- Allow `raLifetime` to be set to `0` to explicitly disable default-router advertisement.
- Validate `raLifetime` as an integer from 0 through 65535. Nonzero values must be at least `raInterval`, per RFC 8319.
- Pass `networkConfig.raLifetime` through the DHCPv6 plugin when generating the dnsmasq configuration.
- Add regression tests covering the default lifetime, a zero lifetime, a custom lifetime, invalid values, values immediately below and equal to `raInterval`, and an omitted lifetime with an interval greater than 3600 seconds.

## Rationale

The IPv6 Router Advertisement Router Lifetime controls whether clients consider the advertising router to be an IPv6 default router. A value of `0` allows Router Advertisements to continue providing IPv6 configuration information without assigning default-router status to the FireRouter interface.

For nonzero values, RFC 8319 requires the Router Lifetime to be at least the maximum Router Advertisement interval. Enforcing `raLifetime >= raInterval` prevents clients from removing the default route before the next advertisement arrives.

The existing hard-coded 3600 value makes this behavior impossible to configure without modifying FireRouter code directly.

For normal configurations, the default remains 3600 seconds, so existing behavior is preserved unless `raLifetime` is explicitly configured. When an existing configuration sets `raInterval` above 3600 seconds and omits `raLifetime`, the effective default lifetime is raised to the interval to satisfy the Router Advertisement lifetime requirement without rejecting the configuration.

This PR is limited to exposing the existing dnsmasq Router Lifetime setting through FireRouter’s DHCPv6 configuration. It does not change DHCPv6 address allocation or Router Advertisement behavior beyond making the Router Lifetime configurable and ensuring the generated lifetime is compatible with the configured RA interval.